### PR TITLE
feat: Open AI API 사용한 가상 면접 챗봇 도입 - be, fe 적용 완료

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -52,6 +52,9 @@ dependencies {
 	implementation 'com.opencsv:opencsv:5.7.1'
 	//swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4'
+	//open ai
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/openAI/InterviewAIController.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/openAI/InterviewAIController.java
@@ -1,0 +1,47 @@
+package com.java.NBE4_5_1_7.domain.openAI;
+
+
+import com.java.NBE4_5_1_7.domain.openAI.dto.InterviewEvaluationDto;
+import com.java.NBE4_5_1_7.domain.openAI.dto.InterviewNextDto;
+import com.java.NBE4_5_1_7.domain.openAI.dto.InterviewStartDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/interview")
+public class InterviewAIController {
+
+    private final OpenAiService openAiService;
+
+    public InterviewAIController(OpenAiService openAiService) {
+        this.openAiService = openAiService;
+    }
+
+    /**
+     * 인터뷰 시작 엔드포인트
+     * 요청 JSON 예: { "interviewType": "CS" } 또는 { "interviewType": "프로젝트" }
+     */
+    @PostMapping("/start")
+    public ResponseEntity<String> startInterview(@RequestBody InterviewStartDto dto) {
+        String response = openAiService.askStartInterview(dto.getInterviewType());
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 인터뷰 진행(후속 질문) 엔드포인트
+     * 요청 JSON 예: { "answer": "사용자 답변", "interviewType": "CS" }
+     */
+    @PostMapping("/next")
+    public ResponseEntity<String> nextInterview(@RequestBody InterviewNextDto dto) {
+        String response = openAiService.askNextInterview(dto.getInterviewType(), dto.getAnswer());
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/evaluation")
+    public ResponseEntity<String> evaluateInterview(@RequestBody InterviewEvaluationDto dto) {
+        String evaluation = openAiService.evaluateInterview(dto.getConversation());
+        return ResponseEntity.ok(evaluation);
+    }
+
+}
+

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/openAI/Message.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/openAI/Message.java
@@ -1,0 +1,27 @@
+package com.java.NBE4_5_1_7.domain.openAI;
+
+public class Message {
+    private String role; // "system", "user", "assistant"
+    private String content;
+
+    public Message() {}
+
+    public Message(String role, String content) {
+        this.role = role;
+        this.content = content;
+    }
+
+    // getters & setters
+    public String getRole() {
+        return role;
+    }
+    public void setRole(String role) {
+        this.role = role;
+    }
+    public String getContent() {
+        return content;
+    }
+    public void setContent(String content) {
+        this.content = content;
+    }
+}

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/openAI/OpenAiService.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/openAI/OpenAiService.java
@@ -1,0 +1,132 @@
+package com.java.NBE4_5_1_7.domain.openAI;
+
+import com.java.NBE4_5_1_7.domain.openAI.dto.ChatRequest;
+import com.java.NBE4_5_1_7.domain.openAI.dto.ChatResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+public class OpenAiService {
+
+    private final WebClient webClient;
+
+    @Value("${openai.api.key}")
+    private String apiKey;
+
+    public OpenAiService(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder.baseUrl("https://api.openai.com/v1").build();
+    }
+
+    /**
+     * 인터뷰 시작 프롬프트를 구성하여 초기 질문 생성
+     */
+    public String askStartInterview(String interviewType) {
+        Message systemMessage;
+        if ("CS".equalsIgnoreCase(interviewType)) {
+            systemMessage = new Message("system",
+                    "당신은 신입 개발자를 대상으로 CS 지식에 관한 기술 면접을 진행하는 면접관입니다. " +
+                            "무작위로 CS 관련 질문을 해주세요.");
+        } else if ("프로젝트".equalsIgnoreCase(interviewType)) {
+            systemMessage = new Message("system",
+                    "당신은 면접관입니다. 면접자의 프로젝트 경험에 대해 면접을 진행합니다. " +
+                            "프로젝트 주제, 맡은 역할, 개발 기능, 어려움, 해결 방법 등을 질문하고, " +
+                            "답변이 부족할 경우 추가 질문을 해주세요.");
+        } else {
+            systemMessage = new Message("system", "면접을 시작합니다.");
+        }
+
+        // 사용자가 인터뷰 주제를 선택했으므로 초기 프롬프트에 대한 user 메시지가 필요없고, system 메시지만 전송
+        List<Message> messages = Arrays.asList(systemMessage);
+        ChatRequest chatRequest = new ChatRequest("gpt-3.5-turbo", messages);
+
+        ChatResponse chatResponse = webClient.post()
+                .uri("/chat/completions")
+                .header("Authorization", "Bearer " + apiKey)
+                .header("Content-Type", "application/json")
+                .bodyValue(chatRequest)
+                .retrieve()
+                .bodyToMono(ChatResponse.class)
+                .block();
+
+        if (chatResponse != null && !chatResponse.getChoices().isEmpty()) {
+            return chatResponse.getChoices().get(0).getMessage().getContent();
+        }
+        return "죄송합니다. 초기 질문을 생성하는 중 오류가 발생했습니다.";
+    }
+
+    /**
+     * 면접 진행 중 후속 질문을 구성
+     */
+    public String askNextInterview(String interviewType, String answer) {
+        Message systemMessage;
+        if ("CS".equalsIgnoreCase(interviewType)) {
+            systemMessage = new Message("system",
+                    "당신은 신입 개발자를 대상으로 CS 지식에 관한 기술 면접을 진행하는 면접관입니다. " +
+                            "지원자의 답변을 평가하고, 후속 질문을 생성하세요." +
+                            "지원자의 답변에 대해 충분한 답이 된 것 같다면 다른 주제로 질문하여 면접을 이어가세요."
+                    );
+        } else if ("프로젝트".equalsIgnoreCase(interviewType)) {
+            systemMessage = new Message("system",
+                    "당신은 면접관입니다. 면접자의 프로젝트 경험에 대해 면접을 진행합니다. " +
+                            "면접자의 답변을 바탕으로 추가 질문이나 피드백을 제공하세요. " +
+                            "프로젝트 주제, 맡은 역할, 개발 기능, 어려움, 해결 방법 등에 대해 구체적으로 물어보세요." +
+                            "해당 프로젝트에서의 사용한 기술이나, 어려움을 극복한 경험 등 심화 질문에 대한 답이 충분히 진행되었다면 다른 질문을 하여 면접을 이어가세요."
+            );
+        } else {
+            systemMessage = new Message("system", "면접을 진행합니다.");
+        }
+
+        Message userMessage = new Message("user", "지원자의 답변: " + answer);
+
+        List<Message> messages = Arrays.asList(systemMessage, userMessage);
+        ChatRequest chatRequest = new ChatRequest("gpt-3.5-turbo", messages);
+
+        ChatResponse chatResponse = webClient.post()
+                .uri("/chat/completions")
+                .header("Authorization", "Bearer " + apiKey)
+                .header("Content-Type", "application/json")
+                .bodyValue(chatRequest)
+                .retrieve()
+                .bodyToMono(ChatResponse.class)
+                .block();
+
+        if (chatResponse != null && !chatResponse.getChoices().isEmpty()) {
+            return chatResponse.getChoices().get(0).getMessage().getContent();
+        }
+        return "죄송합니다. 후속 질문을 생성하는 중 오류가 발생했습니다.";
+    }
+
+    public String evaluateInterview(List<Message> conversation) {
+        // 대화 기록을 문자열로 조합
+        StringBuilder transcript = new StringBuilder();
+        for (Message msg : conversation) {
+            transcript.append(msg.getRole()).append(": ").append(msg.getContent()).append("\n");
+        }
+        String evalPrompt = "아래는 면접 질문 및 답변 목록입니다:\n\n" + transcript.toString() +
+                "\n위 대화 내용을 바탕으로, 각 질문별로 지원자의 답변에서 부족했던 부분과 보완해야 할 점을 분석하고, " +
+                "모범 답변을 제시해주세요." +
+                "특정 기술이나 용어를 제외하고 모든 답변은 한국어로 해야 합니다";
+
+        Message systemMessage = new Message("system", evalPrompt);
+        List<Message> messages = Arrays.asList(systemMessage);
+        ChatRequest chatRequest = new ChatRequest("gpt-3.5-turbo", messages);
+
+        ChatResponse chatResponse = webClient.post()
+                .uri("/chat/completions")
+                .header("Authorization", "Bearer " + apiKey)
+                .header("Content-Type", "application/json")
+                .bodyValue(chatRequest)
+                .retrieve()
+                .bodyToMono(ChatResponse.class)
+                .block();
+
+        if (chatResponse != null && !chatResponse.getChoices().isEmpty()) {
+            return chatResponse.getChoices().get(0).getMessage().getContent();
+        }
+        return "죄송합니다. 평가 결과를 생성하는 중 오류가 발생했습니다.";
+    }
+
+}

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/openAI/dto/ChatRequest.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/openAI/dto/ChatRequest.java
@@ -1,0 +1,31 @@
+package com.java.NBE4_5_1_7.domain.openAI.dto;
+
+import com.java.NBE4_5_1_7.domain.openAI.Message;
+
+import java.util.List;
+
+public class ChatRequest {
+    private String model;
+    private List<Message> messages;
+
+    public ChatRequest() {}
+
+    public ChatRequest(String model, List<Message> messages) {
+        this.model = model;
+        this.messages = messages;
+    }
+
+    // getters & setters
+    public String getModel() {
+        return model;
+    }
+    public void setModel(String model) {
+        this.model = model;
+    }
+    public List<Message> getMessages() {
+        return messages;
+    }
+    public void setMessages(List<Message> messages) {
+        this.messages = messages;
+    }
+}

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/openAI/dto/ChatResponse.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/openAI/dto/ChatResponse.java
@@ -1,0 +1,29 @@
+package com.java.NBE4_5_1_7.domain.openAI.dto;
+
+import com.java.NBE4_5_1_7.domain.openAI.Message;
+
+import java.util.List;
+
+public class ChatResponse {
+    private List<Choice> choices;
+
+    // getters & setters
+    public List<Choice> getChoices() {
+        return choices;
+    }
+    public void setChoices(List<Choice> choices) {
+        this.choices = choices;
+    }
+
+    public static class Choice {
+        private Message message;
+
+        // getters & setters
+        public Message getMessage() {
+            return message;
+        }
+        public void setMessage(Message message) {
+            this.message = message;
+        }
+    }
+}

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/openAI/dto/InterviewEvaluationDto.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/openAI/dto/InterviewEvaluationDto.java
@@ -1,0 +1,17 @@
+package com.java.NBE4_5_1_7.domain.openAI.dto;
+
+import com.java.NBE4_5_1_7.domain.openAI.Message;
+
+import java.util.List;
+
+public class InterviewEvaluationDto {
+    private List<Message> conversation;
+
+    public List<Message> getConversation() {
+        return conversation;
+    }
+
+    public void setConversation(List<Message> conversation) {
+        this.conversation = conversation;
+    }
+}

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/openAI/dto/InterviewNextDto.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/openAI/dto/InterviewNextDto.java
@@ -1,0 +1,21 @@
+package com.java.NBE4_5_1_7.domain.openAI.dto;
+
+
+public class InterviewNextDto {
+    private String answer;
+    private String interviewType;
+
+    public String getAnswer() {
+        return answer;
+    }
+    public void setAnswer(String answer) {
+        this.answer = answer;
+    }
+    public String getInterviewType() {
+        return interviewType;
+    }
+    public void setInterviewType(String interviewType) {
+        this.interviewType = interviewType;
+    }
+}
+

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/openAI/dto/InterviewRequestDto.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/openAI/dto/InterviewRequestDto.java
@@ -1,0 +1,14 @@
+package com.java.NBE4_5_1_7.domain.openAI.dto;
+
+public class InterviewRequestDto {
+    private String answer;
+
+    // getters & setters
+    public String getAnswer() {
+        return answer;
+    }
+
+    public void setAnswer(String answer) {
+        this.answer = answer;
+    }
+}

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/openAI/dto/InterviewStartDto.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/openAI/dto/InterviewStartDto.java
@@ -1,0 +1,12 @@
+package com.java.NBE4_5_1_7.domain.openAI.dto;
+
+public class InterviewStartDto {
+    private String interviewType;
+
+    public String getInterviewType() {
+        return interviewType;
+    }
+    public void setInterviewType(String interviewType) {
+        this.interviewType = interviewType;
+    }
+}

--- a/frontend/src/app/api/techInterview/evaluation/route.ts
+++ b/frontend/src/app/api/techInterview/evaluation/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    // body 내에 conversation 필드가 포함됨 (대화 기록 배열)
+    const response = await fetch(
+      "http://localhost:8080/api/interview/evaluation",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }
+    );
+    const data = await response.text();
+    return NextResponse.json({ response: data });
+  } catch (error) {
+    console.error("Evaluation API error:", error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/api/techInterview/next/route.ts
+++ b/frontend/src/app/api/techInterview/next/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    // body에 answer와 interviewType (후속 질문 시에도 주제 정보 전달)
+    const { answer, interviewType } = body;
+    const response = await fetch("http://localhost:8080/api/interview/next", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ answer, interviewType }),
+    });
+    const data = await response.text();
+    return NextResponse.json({ response: data });
+  } catch (error) {
+    console.error("Error in next route:", error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/api/techInterview/page.tsx
+++ b/frontend/src/app/api/techInterview/page.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import TechInterviewChat from "../../techInterview/TechInterviewChat";
+
+export default function TechInterviewPage() {
+  return (
+    <main style={{ padding: "1rem" }}>
+      <TechInterviewChat />
+    </main>
+  );
+}

--- a/frontend/src/app/api/techInterview/start/route.ts
+++ b/frontend/src/app/api/techInterview/start/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    // body에 interviewType (예: "CS" 또는 "프로젝트")가 포함되어 있음
+    const { interviewType } = body;
+    // Spring 백엔드의 시작 엔드포인트 호출 (환경에 맞게 URL 수정)
+    const response = await fetch("http://localhost:8080/api/interview/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ interviewType }),
+    });
+    const data = await response.text();
+    return NextResponse.json({ response: data });
+  } catch (error) {
+    console.error("Error in start route:", error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/techInterview/TechInterviewChat.tsx
+++ b/frontend/src/app/techInterview/TechInterviewChat.tsx
@@ -1,0 +1,179 @@
+"use client"; // 클라이언트 컴포넌트임을 명시
+
+import React, { useState } from "react";
+import { useRouter } from "next/navigation";
+
+interface Message {
+  role: "user" | "bot";
+  text: string;
+}
+
+export default function TechInterviewChat() {
+  const router = useRouter();
+  // 메시지 기록, 사용자 입력, 인터뷰 주제 관리
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+  const [interviewType, setInterviewType] = useState<"CS" | "프로젝트" | null>(
+    null
+  );
+  // 평가 진행 상태 관리
+  const [isEvaluating, setIsEvaluating] = useState(false);
+
+  // 인터뷰 시작: 주제 선택 버튼 클릭 시
+  const startInterview = async (type: "CS" | "프로젝트") => {
+    setInterviewType(type);
+    try {
+      const res = await fetch("/api/techInterview/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ interviewType: type }),
+      });
+      const data = await res.json();
+      const botMessage: Message = { role: "bot", text: data.response };
+      setMessages([botMessage]);
+    } catch (error) {
+      console.error("Error starting interview:", error);
+      setMessages([
+        { role: "bot", text: "인터뷰 시작 중 오류가 발생했습니다." },
+      ]);
+    }
+  };
+
+  // 답변 전송 및 후속 질문 받기
+  const sendAnswer = async () => {
+    if (!input.trim()) return;
+    const userMessage: Message = { role: "user", text: input };
+    setMessages((prev) => [...prev, userMessage]);
+    try {
+      const res = await fetch("/api/techInterview/next", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ answer: input, interviewType }),
+      });
+      const data = await res.json();
+      const botMessage: Message = { role: "bot", text: data.response };
+      setMessages((prev) => [...prev, botMessage]);
+    } catch (error) {
+      console.error("Error fetching response:", error);
+      setMessages((prev) => [
+        ...prev,
+        { role: "bot", text: "오류가 발생했습니다. 다시 시도해주세요." },
+      ]);
+    }
+    setInput("");
+  };
+
+  // 평가 요청: 평가 진행 중이면 알림, 아니면 평가 API 호출
+  const evaluateInterview = async () => {
+    if (isEvaluating) {
+      alert("답변에 대해 AI 가 정리중입니다. 잠시만 기다려주세요.");
+      return;
+    }
+    setIsEvaluating(true);
+    try {
+      const res = await fetch("/api/techInterview/evaluation", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ conversation: messages }),
+      });
+      const data = await res.json();
+      localStorage.setItem("evaluationResult", data.response);
+      router.push("/techInterview/evaluation");
+    } catch (error) {
+      console.error("Evaluation error:", error);
+      alert("평가 요청 중 오류가 발생했습니다.");
+    } finally {
+      setIsEvaluating(false);
+    }
+  };
+
+  // 주제 선택 전 화면: 두 개의 버튼 제공
+  if (!interviewType) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-gray-200">
+        <div className="bg-white rounded-xl shadow-md p-8 max-w-md text-center">
+          <h1 className="text-2xl font-bold text-gray-800 mb-4">
+            안녕하세요, 기술 면접을 담당하는 AI 면접관 입니다.
+          </h1>
+          <p className="text-gray-600 mb-6">
+            아래 버튼에서 가상 인터뷰 주제를 선택해주세요.
+          </p>
+          <div className="flex justify-center space-x-4">
+            <button
+              onClick={() => startInterview("CS")}
+              className="bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 px-4 rounded-lg shadow-sm"
+            >
+              CS 지식 면접
+            </button>
+            <button
+              onClick={() => startInterview("프로젝트")}
+              className="bg-green-500 hover:bg-green-600 text-white font-semibold py-2 px-4 rounded-lg shadow-sm"
+            >
+              프로젝트 경험 면접
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 인터뷰 진행 중 화면: 채팅 UI + 평가 버튼 추가
+  return (
+    <div className="min-h-screen bg-gray-200 flex flex-col items-center py-10">
+      <div className="bg-white rounded-lg shadow-md w-full max-w-2xl p-6">
+        <h1 className="text-3xl font-bold text-gray-800 text-center mb-6">
+          기술 면접 챗봇
+        </h1>
+        <div className="border border-gray-300 rounded-lg p-4 h-[500px] overflow-y-auto mb-4 bg-gray-50">
+          {messages.map((msg, idx) => (
+            <div
+              key={idx}
+              className={`mb-2 flex ${
+                msg.role === "bot" ? "justify-start" : "justify-end"
+              }`}
+            >
+              <div
+                className={`px-4 py-2 rounded-lg ${
+                  msg.role === "bot"
+                    ? "bg-blue-100 text-blue-800"
+                    : "bg-green-100 text-green-800"
+                }`}
+              >
+                <span className="font-bold">
+                  {msg.role === "bot" ? "면접관" : "지원자"}:
+                </span>{" "}
+                {msg.text}
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="flex flex-col space-y-4">
+          <div className="flex">
+            <textarea
+              value={input}
+              placeholder="답변을 입력하세요..."
+              onChange={(e) => setInput(e.target.value)}
+              className="flex-1 border border-gray-300 rounded-l-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-y min-h-[80px]"
+            />
+            <button
+              onClick={sendAnswer}
+              className="bg-blue-500 hover:bg-blue-600 text-white font-semibold px-4 rounded-r-lg"
+            >
+              전송
+            </button>
+          </div>
+          {/* 평가 버튼, 평가 진행 중일 때 disabled */}
+          <button
+            onClick={evaluateInterview}
+            disabled={isEvaluating}
+            className={`${
+              isEvaluating ? "bg-red-300" : "bg-red-500 hover:bg-red-600"
+            } text-white font-semibold py-2 px-6 rounded-lg shadow-sm mx-auto`}
+          >
+            면접 종료하고 평가 받기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/techInterview/evaluation/page.tsx
+++ b/frontend/src/app/techInterview/evaluation/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function EvaluationPage() {
+  const router = useRouter();
+  const [evaluation, setEvaluation] = useState<string>("");
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      const result = localStorage.getItem("evaluationResult");
+      console.log("evaluationResult:", result);
+      if (result) {
+        setEvaluation(result);
+        localStorage.removeItem("evaluationResult");
+      } else {
+        router.push("/api/techInterview");
+      }
+    }, 300); // 300ms 정도 딜레이
+    return () => clearTimeout(timer);
+  }, [router]);
+
+  return (
+    <div className="min-h-screen bg-gray-100 flex flex-col items-center py-10 px-4">
+      <div className="bg-white rounded-lg shadow-2xl w-full max-w-2xl p-6">
+        <h1 className="text-3xl font-bold text-gray-800 text-center mb-6">
+          면접 평가 결과
+        </h1>
+        <div className="border border-gray-300 rounded-lg p-4 h-[500px] overflow-y-auto bg-gray-50">
+          <pre className="whitespace-pre-wrap text-gray-700">{evaluation}</pre>
+        </div>
+        <button
+          onClick={() => router.push("/techInterview")}
+          className="bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg shadow-md mx-auto mt-4"
+        >
+          다시 면접하기
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📌 과제 설명 Open AI API 를 사용하여 가상 면접 챗봇 서비스 추가

## 👩‍💻 요구 사항과 구현 내용 
- BE : domain/openAI 하위에 코드 작성하였습니다.
- FE : localhost:3000/api/techInterview 확인 가능합니다.

## ✅ PR 포인트 & 궁금한 점 
- slack 의 applicatin-secret.yml 에 open ai api key 확인하시고 적용해주세요
