### PR TITLE
[Feat] 학습 콘텐츠 페이지(관리자) 카테고리 분류와 모달 페이지 추가

### DIFF
--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/study/controller/StudyContentAdminController.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/study/controller/StudyContentAdminController.java
@@ -11,6 +11,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/admin/study")
@@ -19,28 +20,34 @@ public class StudyContentAdminController {
 
     private final StudyContentAdminService studyContentAdminService;
 
-    // 첫 번째 카테고리 목록 조회 (Enum 이름을 한글로 변환하지 않고 그대로 반환)
+    // 모든 카테고리 (첫 번째 카테고리 + 두 번째 카테고리) 조회
     @PreAuthorize("hasRole('ADMIN')")
-    @GetMapping("/categories")
-    public ResponseEntity<List<String>> getFirstCategories() {
-        return ResponseEntity.ok(studyContentAdminService.getFirstCategoryKeys());
+    @GetMapping("/all")
+    public ResponseEntity<Map<String, List<String>>> getAllCategory() {
+        return ResponseEntity.ok(studyContentAdminService.getAllCategory());
     }
 
-    // 특정 카테고리에 대한 학습 콘텐츠 조회 (페이징 처리)
+    // 첫 번째 카테고리에 해당하는 학습 콘텐츠 조회
     @PreAuthorize("hasRole('ADMIN')")
-    @GetMapping
-    public ResponseEntity<Page<StudyContentDetailDto>> getPagedStudyContentsByCategory(
-            @RequestParam String firstCategory,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size) {
+    @GetMapping("/category/{firstCategory}")
+    public ResponseEntity<Page<StudyContentDetailDto>> getPagedStudyContentsByFirstCategory(@PathVariable String firstCategory, @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
 
-        Page<StudyContentDetailDto> studyContents = studyContentAdminService
-                .getPagedStudyContentsByCategory(firstCategory, PageRequest.of(page, size));
+        Page<StudyContentDetailDto> studyContents = studyContentAdminService.getPagedStudyContentsByCategory(firstCategory, PageRequest.of(page, size));
 
         return ResponseEntity.ok(studyContents);
     }
 
-    // 특정 학습 콘텐츠 조회 (ID 기반)
+    // 첫 번째 + 두 번째 카테고리에 해당하는 학습 콘텐츠 조회
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/category/{firstCategory}/{secondCategory}")
+    public ResponseEntity<Page<StudyContentDetailDto>> getPagedStudyContentsByCategories(@PathVariable String firstCategory, @PathVariable String secondCategory, @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
+
+        Page<StudyContentDetailDto> studyContents = studyContentAdminService.getPagedStudyContentsByCategories(firstCategory, secondCategory, PageRequest.of(page, size));
+
+        return ResponseEntity.ok(studyContents);
+    }
+
+    // 학습 콘텐츠 조회
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/{studyContentId}")
     public ResponseEntity<StudyContentDetailDto> getStudyContentById(@PathVariable Long studyContentId) {
@@ -49,17 +56,15 @@ public class StudyContentAdminController {
 
     // 학습 콘텐츠 수정
     @PreAuthorize("hasRole('ADMIN')")
-    @PutMapping("/update/{studyContentId}")
-    public ResponseEntity<String> updateStudyContent(
-            @PathVariable Long studyContentId,
-            @RequestBody StudyContentUpdateRequestDto requestDto) {
-        studyContentAdminService.updateStudyContent(studyContentId, requestDto.getUpdateContent());
+    @PutMapping("/{studyContentId}")
+    public ResponseEntity<String> updateStudyContent(@PathVariable Long studyContentId, @RequestBody StudyContentUpdateRequestDto requestDto) {
+        studyContentAdminService.updateStudyContent(studyContentId, requestDto);
         return ResponseEntity.ok("update success");
     }
 
     // 학습 콘텐츠 삭제
     @PreAuthorize("hasRole('ADMIN')")
-    @DeleteMapping("/delete/{studyContentId}")
+    @DeleteMapping("/{studyContentId}")
     public ResponseEntity<String> deleteStudyContent(@PathVariable Long studyContentId) {
         studyContentAdminService.deleteStudyContent(studyContentId);
         return ResponseEntity.ok("delete success");

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/study/dto/request/StudyContentUpdateRequestDto.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/study/dto/request/StudyContentUpdateRequestDto.java
@@ -6,5 +6,8 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 public class StudyContentUpdateRequestDto {
+    private String title;
+    private String firstCategory;
+    private String secondCategory;
     private String updateContent;
 }

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/study/entity/FirstCategory.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/study/entity/FirstCategory.java
@@ -20,7 +20,7 @@ public enum FirstCategory {
 
     public static FirstCategory fromString(String category) {
         for (FirstCategory c : FirstCategory.values()) {
-            if (c.getCategory().equalsIgnoreCase(category)) {
+            if (c.getCategory().equalsIgnoreCase(category) || c.name().equalsIgnoreCase(category)) {
                 return c;
             }
         }

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/study/service/StudyContentAdminService.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/study/service/StudyContentAdminService.java
@@ -1,6 +1,7 @@
 package com.java.NBE4_5_1_7.domain.study.service;
 
 import com.java.NBE4_5_1_7.domain.study.dto.StudyContentDetailDto;
+import com.java.NBE4_5_1_7.domain.study.dto.request.StudyContentUpdateRequestDto;
 import com.java.NBE4_5_1_7.domain.study.entity.FirstCategory;
 import com.java.NBE4_5_1_7.domain.study.entity.StudyContent;
 import com.java.NBE4_5_1_7.domain.study.repository.StudyContentRepository;
@@ -11,8 +12,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -20,26 +22,28 @@ public class StudyContentAdminService {
 
     private final StudyContentRepository studyContentRepository;
 
-    // 첫 번째 카테고리 목록 조회 (Enum 이름을 한글로 변환하지 않고 그대로 반환)
-    public List<String> getFirstCategoryKeys() {
+    public Map<String, List<String>> getAllCategory() {
+        Map<String, List<String>> categories = new HashMap<>();
         List<FirstCategory> firstCategories = studyContentRepository.findDistinctFirstCategories();
 
         if (firstCategories.isEmpty()) {
             throw new ServiceException("404", "등록된 학습 콘텐츠 카테고리가 없습니다.");
         }
 
-        return firstCategories.stream()
-                .map(FirstCategory::name)
-                .collect(Collectors.toList());
+        for (FirstCategory category : firstCategories) {
+            String firstCategory = category.name();
+            List<String> secondCategories = studyContentRepository.findDistinctBySecondCategory(category);
+            categories.put(firstCategory, secondCategories);
+        }
+        return categories;
     }
 
-    // 특정 카테고리에 대한 학습 콘텐츠 조회
     public Page<StudyContentDetailDto> getPagedStudyContentsByCategory(String firstCategory, Pageable pageable) {
         FirstCategory category;
         try {
             category = FirstCategory.fromString(firstCategory);
         } catch (IllegalArgumentException e) {
-            throw new ServiceException("400", "올바르지 않은 카테고리 값입니다: " + firstCategory);
+            throw new ServiceException("400", "올바르지 않은 첫 번째 카테고리 값입니다: " + firstCategory);
         }
 
         Page<StudyContent> studyContents = studyContentRepository.findByFirstCategory(category, pageable);
@@ -51,27 +55,60 @@ public class StudyContentAdminService {
         return studyContents.map(StudyContentDetailDto::new);
     }
 
-    // 특정 학습 콘텐츠 조회 (ID 기반)
+    public Page<StudyContentDetailDto> getPagedStudyContentsByCategories(String firstCategory, String secondCategory, Pageable pageable) {
+        FirstCategory category;
+        try {
+            category = FirstCategory.fromString(firstCategory);
+        } catch (IllegalArgumentException e) {
+            throw new ServiceException("400", "올바르지 않은 첫 번째 카테고리 값입니다: " + firstCategory);
+        }
+
+        Page<StudyContent> studyContents = studyContentRepository.findByFirstCategoryAndSecondCategory(category, secondCategory, pageable);
+
+        if (studyContents.isEmpty()) {
+            throw new ServiceException("404", "해당 카테고리 조합에 학습 콘텐츠가 존재하지 않습니다.");
+        }
+
+        return studyContents.map(StudyContentDetailDto::new);
+    }
+
     public StudyContentDetailDto getStudyContentById(Long studyContentId) {
-        StudyContent studyContent = studyContentRepository.findById(studyContentId)
-                .orElseThrow(() -> new ServiceException("404", "해당 학습 콘텐츠를 찾을 수 없습니다."));
+        StudyContent studyContent = studyContentRepository.findById(studyContentId).orElseThrow(() -> new ServiceException("404", "해당 학습 콘텐츠를 찾을 수 없습니다."));
         return new StudyContentDetailDto(studyContent);
     }
 
-    // 학습 콘텐츠 수정
     @Transactional
-    public void updateStudyContent(Long studyContentId, String updateContent) {
-        StudyContent studyContent = studyContentRepository.findById(studyContentId)
-                .orElseThrow(() -> new ServiceException("404", "해당 학습 콘텐츠를 찾을 수 없습니다."));
+    public void updateStudyContent(Long studyContentId, StudyContentUpdateRequestDto requestDto) {
+        StudyContent studyContent = studyContentRepository.findById(studyContentId).orElseThrow(() -> new ServiceException("404", "해당 학습 콘텐츠를 찾을 수 없습니다."));
 
-        if (updateContent == null || updateContent.trim().isEmpty()) {
-            throw new ServiceException("400", "수정할 내용이 비어 있습니다.");
+        if (requestDto.getTitle() != null && !requestDto.getTitle().trim().isEmpty()) {
+            studyContent.setTitle(requestDto.getTitle());
         }
 
-        studyContent.setBody(updateContent);
+        if (requestDto.getFirstCategory() != null && !requestDto.getFirstCategory().trim().isEmpty()) {
+            try {
+                FirstCategory newCategory = FirstCategory.fromString(requestDto.getFirstCategory());
+
+                List<FirstCategory> existingCategories = studyContentRepository.findDistinctFirstCategories();
+                if (!existingCategories.contains(newCategory)) {
+                    throw new ServiceException("400", "존재하지 않는 첫 번째 카테고리입니다.");
+                }
+
+                studyContent.setFirstCategory(newCategory);
+            } catch (IllegalArgumentException e) {
+                throw new ServiceException("400", "잘못된 첫 번째 카테고리 값입니다.");
+            }
+        }
+
+        if (requestDto.getSecondCategory() != null && !requestDto.getSecondCategory().trim().isEmpty()) {
+            studyContent.setSecondCategory(requestDto.getSecondCategory());
+        }
+
+        if (requestDto.getUpdateContent() != null && !requestDto.getUpdateContent().trim().isEmpty()) {
+            studyContent.setBody(requestDto.getUpdateContent());
+        }
     }
-    
-    // 학습 콘텐츠 삭제
+
     @Transactional
     public void deleteStudyContent(Long studyContentId) {
         if (!studyContentRepository.existsById(studyContentId)) {

--- a/frontend/src/app/admin/questions/page.tsx
+++ b/frontend/src/app/admin/questions/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { interviewCategories, dummyInterviewQuestions } from "../dummyData";
-import styles from "../../styles/admin.module.css";
+import styles from "../../styles/admin/page.module.css";
 
 export default function QuestionsPage() {
   const [selectedCategory, setSelectedCategory] = useState("");
@@ -57,12 +57,12 @@ export default function QuestionsPage() {
       prevQuestions.map((item) =>
         item.id === editId
           ? {
-              ...item,
-              category: editCategory,
-              keyword: editKeyword,
-              question: editQuestion,
-              answer: editAnswer,
-            }
+            ...item,
+            category: editCategory,
+            keyword: editKeyword,
+            question: editQuestion,
+            answer: editAnswer,
+          }
           : item
       )
     );
@@ -153,27 +153,27 @@ export default function QuestionsPage() {
                   </div>
                 </div>
               ) : (
-                <><div className={ styles.titleContainer}>
-                    <span>{question.question}</span>
-                    <span className={styles.subTitle}>{question.keyword}</span>
-                    </div>
-                  <div className={ styles.buttonContainer}>
-                  <button
-                    className={styles.editBtn}
-                    onClick={() =>
-                      handleEditClick(
-                        question.id,
-                        question.category,
-                        question.keyword,
-                        question.question,
-                        question.answer
-                      )
-                    }
-                  >
-                    수정
-                      </button>
-                  <button className={styles.deleteBtn} onClick={() =>handleDeleteClick(question.id)}>삭제</button>
-                    </div>
+                <><div className={styles.titleContainer}>
+                  <span>{question.question}</span>
+                  <span className={styles.subTitle}>{question.keyword}</span>
+                </div>
+                  <div className={styles.buttonContainer}>
+                    <button
+                      className={styles.editBtn}
+                      onClick={() =>
+                        handleEditClick(
+                          question.id,
+                          question.category,
+                          question.keyword,
+                          question.question,
+                          question.answer
+                        )
+                      }
+                    >
+                      수정
+                    </button>
+                    <button className={styles.deleteBtn} onClick={() => handleDeleteClick(question.id)}>삭제</button>
+                  </div>
                 </>
               )}
             </li>

--- a/frontend/src/app/admin/studyContent/content.tsx
+++ b/frontend/src/app/admin/studyContent/content.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import styles from "../../styles/admin/content.module.css";
+import ContentDetailModal from "./modal/contentDetailModal";
+import ContentEditModal from "./modal/contentEditModal";
+import ContentDeleteModal from "./modal/contentDeleteModal";
+
+const API_URL = "http://localhost:8080/api/v1/admin/study";
+
+interface StudyContentDetailDto {
+  id: number;
+  firstCategory: string;
+  secondCategory: string;
+  title: string;
+  body: string;
+}
+
+interface ContentProps {
+  selectedFirstCategory: string | null;
+  selectedSecondCategory: string | null;
+}
+
+export default function Content({ selectedFirstCategory, selectedSecondCategory }: ContentProps) {
+  const [contents, setContents] = useState<StudyContentDetailDto[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [pageSize, setPageSize] = useState(6);
+  const [totalPages, setTotalPages] = useState(1);
+  const [selectedContent, setSelectedContent] = useState<StudyContentDetailDto | null>(null);
+  const [editContent, setEditContent] = useState<StudyContentDetailDto | null>(null);
+  const [deleteContent, setDeleteContent] = useState<StudyContentDetailDto | null>(null);
+
+  useEffect(() => {
+    if (!selectedFirstCategory) return;
+
+    let url = `${API_URL}/category/${encodeURIComponent(selectedFirstCategory)}`;
+    if (selectedSecondCategory) {
+      url += `/${encodeURIComponent(selectedSecondCategory)}`;
+    }
+    url += `?page=${currentPage}&size=${pageSize}`;
+
+    fetch(url, {
+      method: "GET",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error("콘텐츠를 불러오는 데 실패했습니다.");
+        return res.json();
+      })
+      .then((data) => {
+        setContents(data.content as StudyContentDetailDto[]);
+        setTotalPages(data.totalPages);
+      })
+      .catch((err) => setError(err.message));
+  }, [selectedFirstCategory, selectedSecondCategory, currentPage, pageSize]);
+
+  const handleUpdateContent = (updatedContent: StudyContentDetailDto) => {
+    setContents((prevContents) =>
+      prevContents.map((content) =>
+        content.id === updatedContent.id ? updatedContent : content
+      )
+    );
+    setSelectedContent(null);
+  };
+
+  const handleDeleteContent = (contentId: number) => {
+    setContents((prevContents) => prevContents.filter((content) => content.id !== contentId));
+    setDeleteContent(null);
+  };
+
+  return (
+    <main className={styles.contentContainer}>
+      {error && <p style={{ color: "red" }}>{error}</p>}
+      <ul className={styles.contentList}>
+        {contents.length > 0 ? (
+          contents.map((content) => (
+            <li key={content.id} className={styles.contentItem}>
+              <div className={styles.titleContainer}>
+                <span>{content.title}</span>
+                <span className={styles.subTitle}>{content.secondCategory}</span>
+              </div>
+
+              <div className={styles.buttonGroup}>
+                <button className={styles.detailButton} onClick={() => setSelectedContent(content)}>
+                  상세 보기
+                </button>
+                <button className={styles.editButton} onClick={() => setEditContent(content)}>
+                  수정
+                </button>
+                <button className={styles.deleteButton} onClick={() => setDeleteContent(content)}>
+                  삭제
+                </button>
+              </div>
+            </li>
+          ))
+        ) : (
+          <p>콘텐츠가 없습니다.</p>
+        )}
+      </ul>
+
+      <div className={styles.pagination}>
+        <button onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 0))} disabled={currentPage === 0}>
+          ⬅
+        </button>
+        <span>{currentPage + 1} / {totalPages}</span>
+        <button onClick={() => setCurrentPage((prev) => (prev < totalPages - 1 ? prev + 1 : prev))} disabled={currentPage === totalPages - 1}>
+          ➡
+        </button>
+      </div>
+
+      {selectedContent && (
+        <ContentDetailModal content={selectedContent} onClose={() => setSelectedContent(null)} />
+      )}
+
+      {editContent && (
+        <ContentEditModal
+          content={editContent}
+          onClose={() => setEditContent(null)}
+          onUpdate={handleUpdateContent}
+        />
+      )}
+
+      {deleteContent && (
+        <ContentDeleteModal content={deleteContent} onClose={() => setDeleteContent(null)} onDelete={handleDeleteContent} />
+      )}
+    </main>
+  );
+}

--- a/frontend/src/app/admin/studyContent/modal/contentDeleteModal.tsx
+++ b/frontend/src/app/admin/studyContent/modal/contentDeleteModal.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import styles from "../../../styles/admin/modal/contentDeleteModal.module.css";
+
+const API_URL = "http://localhost:8080/api/v1/admin/study";
+
+interface ContentDeleteModalProps {
+  content: { id: number; title: string };
+  onClose: () => void;
+  onDelete: (contentId: number) => void;
+}
+
+export default function ContentDeleteModal({ content, onClose, onDelete }: ContentDeleteModalProps) {
+  const handleDelete = async () => {
+    try {
+      console.log(`삭제 요청: ${API_URL}/${content.id}`);
+
+      const response = await fetch(`${API_URL}/${content.id}`, {
+        method: "DELETE",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const responseText = await response.text();
+      console.log("서버 응답:", responseText);
+
+      if (!response.ok) {
+        throw new Error(`삭제 실패: ${response.status} ${responseText}`);
+      }
+
+      onDelete(content.id);
+      onClose();
+    } catch (error: any) {
+      console.error("삭제 오류:", error);
+      alert(`삭제 중 오류가 발생했습니다: ${error.message}`);
+    }
+  };
+
+  return (
+    <div className={styles.modalOverlay}>
+      <div className={styles.modalContent}>
+        <h2>삭제 확인</h2>
+        <p>"{content.title}"을(를) 삭제하시겠습니까?</p>
+        <div className={styles.buttonGroup}>
+          <button onClick={handleDelete} className={styles.deleteButton}>
+            삭제
+          </button>
+          <button onClick={onClose} className={styles.cancelButton}>
+            취소
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/studyContent/modal/contentDetailModal.tsx
+++ b/frontend/src/app/admin/studyContent/modal/contentDetailModal.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import React from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeRaw from "rehype-raw";
+import styles from "../../../styles/admin/modal/contentDetailModal.module.css";
+
+interface ContentDetailModalProps {
+  content: {
+    title: string;
+    firstCategory: string;
+    secondCategory: string;
+    body: string;
+  };
+  onClose: () => void;
+}
+
+const ContentDetailModal: React.FC<ContentDetailModalProps> = ({ content, onClose }) => {
+  return (
+    <div className={styles.modalOverlay}>
+      <div className={styles.modalContent}>
+        <h2 className={styles.modalTitle}>{content.title}</h2>
+        <p className={styles.modalCategory}>
+          {content.firstCategory} / {content.secondCategory}
+        </p>
+
+        <div className={styles.modalBody}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
+            {content.body}
+          </ReactMarkdown>
+        </div>
+
+        <div className={styles.modalFooter}>
+          <button className={styles.closeButton} onClick={onClose}>
+            닫기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ContentDetailModal;

--- a/frontend/src/app/admin/studyContent/modal/contentEditModal.tsx
+++ b/frontend/src/app/admin/studyContent/modal/contentEditModal.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import styles from "../../../styles/admin/modal/contentEditModal.module.css";
+
+const API_URL = "http://localhost:8080/api/v1/admin/study";
+
+interface StudyContentDetailDto {
+  id: number;
+  firstCategory: string;
+  secondCategory: string;
+  title: string;
+  body: string;
+}
+
+interface StudyContentUpdateRequestDto {
+  title: string;
+  firstCategory: string;
+  secondCategory: string;
+  updateContent: string;
+}
+
+interface ContentEditModalProps {
+  content: StudyContentDetailDto;
+  onClose: () => void;
+  onUpdate: (updatedContent: StudyContentDetailDto) => void;
+}
+
+export default function ContentEditModal({ content, onClose, onUpdate }: ContentEditModalProps) {
+  const [title, setTitle] = useState(content.title);
+  const [firstCategory, setFirstCategory] = useState(content.firstCategory);
+  const [secondCategory, setSecondCategory] = useState(content.secondCategory);
+  const [updateContent, setUpdateContent] = useState(content.body);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [categories, setCategories] = useState<string[]>([]);
+
+  useEffect(() => {
+    fetch(`${API_URL}/all`, {
+      method: "GET",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+    })
+      .then(async (res) => {
+        if (!res.ok) {
+          throw new Error(`서버 오류 발생: ${res.status}`);
+        }
+        return res.json();
+      })
+      .then((data) => {
+        const firstKeys = Object.keys(data);
+        setCategories(firstKeys);
+
+        if (!firstCategory && firstKeys.length > 0) {
+          setFirstCategory(firstKeys[0]);
+        }
+      })
+      .catch(() => {
+        setError("카테고리를 불러오는 데 실패했습니다.");
+      });
+  }, []);
+
+  const handleSave = async () => {
+    setLoading(true);
+    setError(null);
+
+    const updatedData: StudyContentUpdateRequestDto = {
+      title: title.trim() !== "" ? title : content.title,
+      firstCategory,
+      secondCategory,
+      updateContent,
+    };
+
+    try {
+      const response = await fetch(`${API_URL}/${content.id}`, {
+        method: "PUT",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(updatedData),
+      });
+
+      let responseData;
+      const responseText = await response.text();
+
+      try {
+        responseData = JSON.parse(responseText);
+      } catch (error) {
+        responseData = responseText;
+      }
+
+      if (!response.ok) {
+        throw new Error(responseData.message || responseData || "수정에 실패했습니다.");
+      }
+
+      const updatedContent: StudyContentDetailDto = {
+        id: content.id,
+        firstCategory,
+        secondCategory,
+        title,
+        body: updateContent,
+      };
+
+      onUpdate(updatedContent);
+      onClose();
+    } catch (error: any) {
+      setError(error.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className={styles.modalOverlay}>
+      <div className={styles.modalContent}>
+        <h2>콘텐츠 수정</h2>
+
+        {error && <p className={styles.errorMessage}>{error}</p>}
+
+        <label>제목:</label>
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className={styles.inputField}
+        />
+
+        <label>첫 번째 카테고리:</label>
+        <select
+          value={firstCategory}
+          onChange={(e) => setFirstCategory(e.target.value)}
+          className={styles.selectField}
+        >
+          {categories.length > 0 ? (
+            categories.map((category) => (
+              <option key={category} value={category}>
+                {category}
+              </option>
+            ))
+          ) : (
+            <option disabled>카테고리를 불러오는 중...</option>
+          )}
+        </select>
+
+        <label>두 번째 카테고리:</label>
+        <input
+          type="text"
+          value={secondCategory}
+          onChange={(e) => setSecondCategory(e.target.value)}
+          className={styles.inputField}
+          placeholder="새로운 카테고리를 입력하세요"
+        />
+
+        <label>내용:</label>
+        <textarea
+          value={updateContent}
+          onChange={(e) => setUpdateContent(e.target.value)}
+          className={styles.textareaField}
+          rows={5}
+        />
+
+        <div className={styles.buttonGroup}>
+          <button onClick={handleSave} disabled={loading} className={styles.saveButton}>
+            {loading ? "저장 중..." : "저장"}
+          </button>
+          <button onClick={onClose} className={styles.cancelButton}>취소</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/studyContent/page.tsx
+++ b/frontend/src/app/admin/studyContent/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useState } from "react";
+import styles from "../../styles/admin/page.module.css";
+import Sidebar from "./sidebar";
+import Content from "./content";
+
+export default function AdminContentPage() {
+  const [selectedFirstCategory, setSelectedFirstCategory] = useState<string | null>(null);
+  const [selectedSecondCategory, setSelectedSecondCategory] = useState<string | null>(null);
+
+  return (
+    <div className={styles.adminContainer}>
+      <Sidebar
+        selectedFirstCategory={selectedFirstCategory}
+        setSelectedFirstCategory={setSelectedFirstCategory}
+        selectedSecondCategory={selectedSecondCategory}
+        setSelectedSecondCategory={setSelectedSecondCategory}
+      />
+      <Content
+        selectedFirstCategory={selectedFirstCategory}
+        selectedSecondCategory={selectedSecondCategory}
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/admin/studyContent/sidebar.tsx
+++ b/frontend/src/app/admin/studyContent/sidebar.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import styles from "../../styles/admin/sidebar.module.css";
+
+const API_URL = "http://localhost:8080/api/v1/admin/study";
+
+interface SidebarProps {
+  selectedFirstCategory: string | null;
+  setSelectedFirstCategory: (category: string) => void;
+  selectedSecondCategory: string | null;
+  setSelectedSecondCategory: (category: string | null) => void;
+}
+
+export default function Sidebar({
+  selectedFirstCategory,
+  setSelectedFirstCategory,
+  selectedSecondCategory,
+  setSelectedSecondCategory,
+}: SidebarProps) {
+  const [categories, setCategories] = useState<{ [key: string]: string[] }>({});
+  const [openCategory, setOpenCategory] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`${API_URL}/all`, {
+      method: "GET",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error("카테고리 목록을 불러오지 못했습니다.");
+        return res.json();
+      })
+      .then((data) => {
+        setCategories(data);
+        const firstCategoryKeys = Object.keys(data);
+        if (firstCategoryKeys.length > 0 && !selectedFirstCategory) {
+          setSelectedFirstCategory(firstCategoryKeys[0]);
+        }
+      })
+      .catch((err) => console.error(err));
+  }, []);
+
+  return (
+    <aside className={styles.sidebar}>
+      <ul className={styles.categoryList}>
+        {Object.keys(categories).map((firstCategory) => (
+          <div key={firstCategory} className={styles.categoryWrapper}>
+            <li className={styles.categoryItem}>
+              <button
+                className={`${styles.categoryButton} ${firstCategory === selectedFirstCategory ? styles.active : ""
+                  }`}
+                onClick={() => {
+                  if (openCategory === firstCategory) {
+                    setOpenCategory(null);
+                  } else {
+                    setSelectedFirstCategory(firstCategory);
+                    setSelectedSecondCategory(null);
+                    setOpenCategory(firstCategory);
+                  }
+                }}
+              >
+                {firstCategory}
+                <span className={styles.arrowIcon}>
+                  {openCategory === firstCategory ? "▲" : "▼"}
+                </span>
+              </button>
+            </li>
+            {openCategory === firstCategory && categories[firstCategory].length > 0 && (
+              <ul className={styles.dropdownMenu}>
+                {categories[firstCategory].map((secondCategory) => (
+                  <li
+                    key={secondCategory}
+                    className={styles.dropdownItem}
+                    onClick={() => setSelectedSecondCategory(secondCategory)}
+                  >
+                    {secondCategory}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/frontend/src/app/components/Header.tsx
+++ b/frontend/src/app/components/Header.tsx
@@ -36,7 +36,7 @@ export default function Header() {
                 <Link href="/admin">관리자 홈</Link>
               </li>
               <li>
-                <Link href="/admin/content">학습 콘텐츠 관리</Link>
+                <Link href="/admin/studyContent">학습 콘텐츠 관리</Link>
               </li>
               <li>
                 <Link href="/admin/questions">질문 관리</Link>

--- a/frontend/src/app/styles/admin/content.module.css
+++ b/frontend/src/app/styles/admin/content.module.css
@@ -1,0 +1,119 @@
+/* 콘텐츠 리스트 컨테이너 */
+.contentContainer {
+  flex-grow: 1;
+  margin-left: 20px;
+  max-width: 800px;
+}
+
+/* 콘텐츠 리스트 */
+.contentList {
+  list-style: none;
+  padding: 0;
+}
+
+/* 개별 콘텐츠 아이템 */
+.contentItem {
+  background: #ffffff;
+  padding: 15px;
+  border-radius: 8px;
+  margin-bottom: 10px;
+  box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.1);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+/* 콘텐츠 제목 스타일 */
+.titleContainer {
+  display: flex;
+  flex-direction: column;
+}
+
+/* 부제목 (두 번째 카테고리) */
+.subTitle {
+  font-size: 14px;
+  color: #6c757d;
+  margin-top: 4px;
+}
+
+/* 버튼 그룹 */
+.buttonGroup {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+}
+
+/* 상세 보기 버튼 */
+.detailButton {
+  background: #1976d2;
+  color: white;
+  padding: 6px 12px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.detailButton:hover {
+  background: #155a9f;
+}
+
+/* 수정 버튼 */
+.editButton {
+  background: #4caf50;
+  color: white;
+  padding: 6px 12px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.editButton:hover {
+  background: #388e3c;
+}
+
+/* 삭제 버튼 */
+.deleteButton {
+  background: #ff4444;
+  color: white;
+  padding: 6px 12px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.deleteButton:hover {
+  background: #cc0000;
+}
+
+/* 페이징 컨트롤 */
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 20px;
+}
+
+.pagination button {
+  padding: 8px 12px;
+  font-size: 16px;
+  border: none;
+  background-color: #007bff;
+  color: white;
+  border-radius: 5px;
+  cursor: pointer;
+  margin: 0 5px;
+}
+
+.pagination button:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+
+/* 오류 메시지 */
+.errorMessage {
+  color: red;
+  font-weight: bold;
+  text-align: center;
+  margin-top: 10px;
+}

--- a/frontend/src/app/styles/admin/modal/contentDeleteModal.module.css
+++ b/frontend/src/app/styles/admin/modal/contentDeleteModal.module.css
@@ -1,0 +1,76 @@
+/* 모달 배경 (오버레이) */
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+/* 모달 본문 */
+.modalContent {
+  background: white;
+  width: 380px;
+  max-width: 90%;
+  padding: 10px;
+  border-radius: 10px;
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);
+  text-align: center;
+}
+
+/* 모달 제목 */
+.modalContent h2 {
+  font-size: 20px;
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
+/* 모달 본문 텍스트 */
+.modalContent p {
+  font-size: 16px;
+  color: #333;
+  margin-bottom: 20px;
+}
+
+/* 버튼 그룹 */
+.buttonGroup {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+/* 삭제 버튼 */
+.deleteButton {
+  background: #ff4444;
+  color: white;
+  padding: 10px 16px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.deleteButton:hover {
+  background: #cc0000;
+}
+
+/* 취소 버튼 */
+.cancelButton {
+  background: #6c757d;
+  color: white;
+  padding: 10px 16px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.cancelButton:hover {
+  background: #5a6268;
+}

--- a/frontend/src/app/styles/admin/modal/contentDetailModal.module.css
+++ b/frontend/src/app/styles/admin/modal/contentDetailModal.module.css
@@ -1,0 +1,63 @@
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modalContent {
+  background: white;
+  width: 60%;
+  max-width: 800px;
+  padding: 20px;
+  border-radius: 10px;
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+}
+
+.modalTitle {
+  font-size: 22px;
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
+.modalCategory {
+  font-size: 14px;
+  color: #666;
+  margin-bottom: 15px;
+}
+
+.modalBody {
+  max-height: 400px;
+  overflow-y: auto;
+  padding-right: 10px;
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+.modalFooter {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 15px;
+}
+
+.closeButton {
+  background-color: #f44336;
+  color: white;
+  padding: 10px 16px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.closeButton:hover {
+  background-color: #d32f2f;
+}

--- a/frontend/src/app/styles/admin/modal/contentEditModal.module.css
+++ b/frontend/src/app/styles/admin/modal/contentEditModal.module.css
@@ -1,0 +1,121 @@
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modalContent {
+  background: white;
+  width: 60%;
+  max-width: 800px;
+  padding: 20px;
+  border-radius: 10px;
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+}
+
+.modalTitle {
+  font-size: 22px;
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
+.modalCategory {
+  font-size: 14px;
+  color: #666;
+  margin-bottom: 15px;
+}
+
+.modalBody {
+  max-height: 400px;
+  overflow-y: auto;
+  padding-right: 10px;
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+.inputField,
+.textareaField,
+.selectField {
+  width: 100%;
+  padding: 10px;
+  margin: 8px 0;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  font-size: 16px;
+}
+
+.selectField {
+  width: 100%;
+  padding: 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: white;
+  font-size: 16px;
+}
+
+.scrollableDropdown {
+  max-height: 200px;
+  overflow-y: auto;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: white;
+  padding: 5px;
+}
+
+.textareaField {
+  resize: vertical;
+  min-height: 150px;
+}
+
+.buttonGroup {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 15px;
+}
+
+.saveButton {
+  background: #4caf50;
+  color: white;
+  padding: 10px 16px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 14px;
+  margin-right: 10px;
+}
+
+.cancelButton {
+  background: #f44336;
+  color: white;
+  padding: 10px 16px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.closeButton {
+  position: absolute;
+  bottom: 15px;
+  right: 15px;
+  background-color: #f44336;
+  color: white;
+  padding: 10px 16px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.closeButton:hover {
+  background-color: #d32f2f;
+}

--- a/frontend/src/app/styles/admin/page.module.css
+++ b/frontend/src/app/styles/admin/page.module.css
@@ -1,0 +1,11 @@
+/* 전체 페이지 컨테이너 */
+.adminContainer {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  width: 100%;
+  height: 90%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 10px;
+}

--- a/frontend/src/app/styles/admin/sidebar.module.css
+++ b/frontend/src/app/styles/admin/sidebar.module.css
@@ -1,0 +1,79 @@
+/* 사이드바 컨테이너 */
+.sidebar {
+  width: 270px;
+  background: #f8f9fa;
+  padding: 15px;
+  margin-right: 20px;
+  border-radius: 10px;
+  box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+/* 카테고리 리스트 */
+.categoryList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+/* 개별 카테고리 아이템 */
+.categoryWrapper {
+  margin-bottom: 10px;
+}
+
+/* 카테고리 버튼 */
+.categoryButton {
+  width: 100%;
+  padding: 12px;
+  font-size: 16px;
+  font-weight: bold;
+  background-color: #ffffff;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  transition: background-color 0.3s;
+}
+
+.categoryButton:hover {
+  background: #eaeaea;
+}
+
+.categoryButton.active {
+  background: #e0e0e0;
+}
+
+/* 드롭다운 메뉴 */
+.dropdownMenu {
+  list-style: none;
+  padding: 0;
+  margin-top: 5px;
+  background-color: white;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  max-height: 200px;
+  overflow-y: auto;
+  box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.2);
+  position: relative;
+}
+
+/* 드롭다운 아이템 */
+.dropdownItem {
+  padding: 10px;
+  cursor: pointer;
+  border-bottom: 1px solid #ddd;
+}
+
+.dropdownItem:last-child {
+  border-bottom: none;
+}
+
+.dropdownItem:hover {
+  background-color: #f1f1f1;
+}
+
+/* 화살표 아이콘 */
+.arrowIcon {
+  font-size: 14px;
+}


### PR DESCRIPTION
## 연관된 이슈

> #58

## 작업 내용

 - 첫번 째 카테고리 값 또는 두번 째 카테고리를 포함한 콘텐츠 조회
 - 콘텐츠 상세 조회, 수정, 삭제 모달 페이지 추가
 - css 파일 정리

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/3ab5fe6c-2abd-4207-be37-f79402f25992)
![image](https://github.com/user-attachments/assets/5498ebe9-a02a-462f-bb0e-e7ae31418c0a)
![image](https://github.com/user-attachments/assets/54bc6ba7-734a-45d4-a6c5-313df222dbeb)
![image](https://github.com/user-attachments/assets/a6691afc-b0b6-4766-9721-8149a89f7ccf)
## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
