### PR TITLE
refactor:로그인 권한 확인 로직 수정#101

### DIFF
--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/member/entity/Member.java
@@ -54,6 +54,8 @@ public class Member extends BaseEntity{
 
         List<String> authorities = new ArrayList<>();
 
+        authorities.add("ROLE_USER");
+
         if(isAdmin()) {
             authorities.add("ROLE_ADMIN");
         }

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/study/controller/StudyContentAdminController.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/study/controller/StudyContentAdminController.java
@@ -8,6 +8,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -21,14 +23,16 @@ public class StudyContentAdminController {
     private final StudyContentAdminService studyContentAdminService;
 
     // 모든 카테고리 (첫 번째 카테고리 + 두 번째 카테고리) 조회
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     @GetMapping("/all")
     public ResponseEntity<Map<String, List<String>>> getAllCategory() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        System.out.println("Current authorities: " + auth.getAuthorities());
         return ResponseEntity.ok(studyContentAdminService.getAllCategory());
     }
 
     // 첫 번째 카테고리에 해당하는 학습 콘텐츠 조회
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     @GetMapping("/category/{firstCategory}")
     public ResponseEntity<Page<StudyContentDetailDto>> getPagedStudyContentsByFirstCategory(@PathVariable String firstCategory, @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
 
@@ -38,7 +42,7 @@ public class StudyContentAdminController {
     }
 
     // 첫 번째 + 두 번째 카테고리에 해당하는 학습 콘텐츠 조회
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     @GetMapping("/category/{firstCategory}/{secondCategory}")
     public ResponseEntity<Page<StudyContentDetailDto>> getPagedStudyContentsByCategories(@PathVariable String firstCategory, @PathVariable String secondCategory, @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
 
@@ -48,14 +52,14 @@ public class StudyContentAdminController {
     }
 
     // 학습 콘텐츠 조회
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     @GetMapping("/{studyContentId}")
     public ResponseEntity<StudyContentDetailDto> getStudyContentById(@PathVariable Long studyContentId) {
         return ResponseEntity.ok(studyContentAdminService.getStudyContentById(studyContentId));
     }
 
     // 학습 콘텐츠 수정
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     @PutMapping("/{studyContentId}")
     public ResponseEntity<String> updateStudyContent(@PathVariable Long studyContentId, @RequestBody StudyContentUpdateRequestDto requestDto) {
         studyContentAdminService.updateStudyContent(studyContentId, requestDto);
@@ -63,7 +67,7 @@ public class StudyContentAdminController {
     }
 
     // 학습 콘텐츠 삭제
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     @DeleteMapping("/{studyContentId}")
     public ResponseEntity<String> deleteStudyContent(@PathVariable Long studyContentId) {
         studyContentAdminService.deleteStudyContent(studyContentId);

--- a/backend/src/main/java/com/java/NBE4_5_1_7/global/dataInit/InterviewContentDataInit.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/global/dataInit/InterviewContentDataInit.java
@@ -20,7 +20,7 @@ import java.nio.charset.StandardCharsets;
 public class InterviewContentDataInit {
     private final InterviewContentRepository repository;
 
-//    @PostConstruct
+    @PostConstruct
     public void dataInit() {
         importCsvData();
         updateHasTailField();

--- a/backend/src/main/java/com/java/NBE4_5_1_7/global/dataInit/StudyContentDataInit.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/global/dataInit/StudyContentDataInit.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 public class StudyContentDataInit {
     private final StudyContentRepository repository;
 
-//    @PostConstruct
+    @PostConstruct
     public void importCsvData() {
         try {
             // 프로젝트 상위 디렉토리의 data 폴더 내 CSV 파일 경로 (파일명은 실제 사용 파일명으로 수정)

--- a/backend/src/main/java/com/java/NBE4_5_1_7/global/security/CustomAuthenticationFilter.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/global/security/CustomAuthenticationFilter.java
@@ -84,7 +84,13 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
 
-        rq.setLogin(actor);
+        Member freshActor = memberService.findById(actor.getId()).orElse(null);
+        if (freshActor != null) {
+            rq.setLogin(freshActor);
+        } else {
+            rq.setLogin(actor);
+        }
+
         filterChain.doFilter(request, response);
     }
 }

--- a/backend/src/main/java/com/java/NBE4_5_1_7/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/global/security/SecurityConfig.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -18,6 +19,7 @@ import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
 
@@ -30,6 +32,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((authorizeHttpRequests) ->
                         authorizeHttpRequests
                                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/member/**", "/api/v1/study/**", "/api/interview/**").permitAll()
+                                .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                                 .anyRequest().authenticated()
                 )
                 .cors(Customizer.withDefaults())

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.0.1",
+    "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.0.2",
     "tailwindcss-animate": "^1.0.7"

--- a/frontend/src/lib/backend/apiV1/schema.d.ts
+++ b/frontend/src/lib/backend/apiV1/schema.d.ts
@@ -20,17 +20,17 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/admin/study/update/{studyContentId}": {
+    "/api/v1/admin/study/{studyContentId}": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        get: operations["getStudyContentById"];
         put: operations["updateStudyContent_1"];
         post?: never;
-        delete?: never;
+        delete: operations["deleteStudyContent"];
         options?: never;
         head?: never;
         patch?: never;
@@ -468,14 +468,14 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/admin/study": {
+    "/api/v1/admin/study/category/{firstCategory}": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        get: operations["getPagedStudyContentsByCategory"];
+        get: operations["getPagedStudyContentsByFirstCategory"];
         put?: never;
         post?: never;
         delete?: never;
@@ -484,14 +484,14 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/admin/study/{studyContentId}": {
+    "/api/v1/admin/study/category/{firstCategory}/{secondCategory}": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        get: operations["getStudyContentById"];
+        get: operations["getPagedStudyContentsByCategories"];
         put?: never;
         post?: never;
         delete?: never;
@@ -500,14 +500,14 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/admin/study/categories": {
+    "/api/v1/admin/study/all": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        get: operations["getFirstCategories"];
+        get: operations["getAllCategory_1"];
         put?: never;
         post?: never;
         delete?: never;
@@ -574,22 +574,6 @@ export interface paths {
         get?: never;
         put?: never;
         post?: never;
-        delete: operations["deleteStudyContent"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/admin/study/delete/{studyContentId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
         delete: operations["deleteStudyContent_1"];
         options?: never;
         head?: never;
@@ -606,6 +590,9 @@ export interface components {
             data: Record<string, never>;
         };
         StudyContentUpdateRequestDto: {
+            title?: string;
+            firstCategory?: string;
+            secondCategory?: string;
             updateContent?: string;
         };
         RsDataString: {
@@ -719,31 +706,31 @@ export interface components {
             first?: boolean;
             last?: boolean;
             /** Format: int32 */
+            numberOfElements?: number;
+            pageable?: components["schemas"]["PageableObject"];
+            /** Format: int32 */
             size?: number;
             content?: components["schemas"]["StudyContentDetailDto"][];
             /** Format: int32 */
             number?: number;
             sort?: components["schemas"]["SortObject"];
-            /** Format: int32 */
-            numberOfElements?: number;
-            pageable?: components["schemas"]["PageableObject"];
             empty?: boolean;
         };
         PageableObject: {
+            paged?: boolean;
+            /** Format: int32 */
+            pageSize?: number;
+            /** Format: int32 */
+            pageNumber?: number;
+            unpaged?: boolean;
             /** Format: int64 */
             offset?: number;
             sort?: components["schemas"]["SortObject"];
-            paged?: boolean;
-            /** Format: int32 */
-            pageNumber?: number;
-            /** Format: int32 */
-            pageSize?: number;
-            unpaged?: boolean;
         };
         SortObject: {
-            empty?: boolean;
             sorted?: boolean;
             unsorted?: boolean;
+            empty?: boolean;
         };
         StudyContentDetailDto: {
             /** Format: int64 */
@@ -811,6 +798,37 @@ export interface operations {
             };
         };
     };
+    getStudyContentById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                studyContentId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["StudyContentDetailDto"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["RsDataVoid"];
+                };
+            };
+        };
+    };
     updateStudyContent_1: {
         parameters: {
             query?: never;
@@ -825,6 +843,37 @@ export interface operations {
                 "application/json": components["schemas"]["StudyContentUpdateRequestDto"];
             };
         };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": string;
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["RsDataVoid"];
+                };
+            };
+        };
+    };
+    deleteStudyContent: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                studyContentId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
         responses: {
             /** @description OK */
             200: {
@@ -1825,15 +1874,16 @@ export interface operations {
             };
         };
     };
-    getPagedStudyContentsByCategory: {
+    getPagedStudyContentsByFirstCategory: {
         parameters: {
-            query: {
-                firstCategory: string;
+            query?: {
                 page?: number;
                 size?: number;
             };
             header?: never;
-            path?: never;
+            path: {
+                firstCategory: string;
+            };
             cookie?: never;
         };
         requestBody?: never;
@@ -1858,12 +1908,16 @@ export interface operations {
             };
         };
     };
-    getStudyContentById: {
+    getPagedStudyContentsByCategories: {
         parameters: {
-            query?: never;
+            query?: {
+                page?: number;
+                size?: number;
+            };
             header?: never;
             path: {
-                studyContentId: number;
+                firstCategory: string;
+                secondCategory: string;
             };
             cookie?: never;
         };
@@ -1875,7 +1929,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "*/*": components["schemas"]["StudyContentDetailDto"];
+                    "*/*": components["schemas"]["PageStudyContentDetailDto"];
                 };
             };
             /** @description Internal Server Error */
@@ -1889,7 +1943,7 @@ export interface operations {
             };
         };
     };
-    getFirstCategories: {
+    getAllCategory_1: {
         parameters: {
             query?: never;
             header?: never;
@@ -1904,7 +1958,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "*/*": string[];
+                    "*/*": {
+                        [key: string]: string[];
+                    };
                 };
             };
             /** @description Internal Server Error */
@@ -1982,37 +2038,6 @@ export interface operations {
             header?: never;
             path: {
                 noteId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": string;
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["RsDataVoid"];
-                };
-            };
-        };
-    };
-    deleteStudyContent: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                studyContentId: number;
             };
             cookie?: never;
         };


### PR DESCRIPTION
## 연관된 이슈
#82 - 관리자 페이지 접근 권한 로직 수정

## 변경 사항
- 인증된 유저에대한 권한 내용을 유저 정보 생성 시 DB에서 확인하여 최신화 할 수 있게 변경
- OAUTH인증 정보에 권한 정보 포함
- admin 페이지의 API 사용권한을 관리자만 접근 가능하도록 변경