### PR TITLE
feat: 면접 질문 관리 페이지(관리자) API 연결

### DIFF
--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/controller/InterviewAdminController.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/controller/InterviewAdminController.java
@@ -1,0 +1,50 @@
+package com.java.NBE4_5_1_7.domain.interview.controller;
+
+import com.java.NBE4_5_1_7.domain.interview.entity.InterviewCategory;
+import com.java.NBE4_5_1_7.domain.interview.entity.dto.response.InterviewContentAdminResponseDto;
+import com.java.NBE4_5_1_7.domain.interview.service.InterviewAdminService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@Tag(name = "면접 질문 관리", description = "관리자가 면접 질문을 관리하는 API")
+@RestController
+@RequestMapping("/api/v1/admin/interview")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class InterviewAdminController {
+
+    private final InterviewAdminService interviewAdminService;
+    @Operation(summary = "카테고리별 키워드 조회", description = "각 카테고리 내 키워드 목록을 조회합니다.")
+    @GetMapping("/all")
+    public ResponseEntity<Map<String, List<String>>> getCategoryKeywords() {
+        return ResponseEntity.ok(interviewAdminService.getCategoryKeywords());
+    }
+
+    @Operation(summary = "특정 카테고리의 모든 질문 조회", description = "선택한 카테고리에 속하는 모든 면접 질문 데이터를 조회합니다.")
+    @GetMapping("/category/{Category}")
+    public ResponseEntity<List<InterviewContentAdminResponseDto>> getInterviewsByCategory(
+            @Parameter(description = "조회할 카테고리", example = "DATABASE")
+            @PathVariable("Category") InterviewCategory category) {
+        return ResponseEntity.ok(interviewAdminService.getInterviewsByCategory(category));
+    }
+
+    @Operation(summary = "특정 카테고리의 키워드에 해당하는 모든 질문 조회",
+            description = "선택한 카테고리 내에서 특정 키워드를 포함하는 면접 질문을 조회합니다.")
+    @GetMapping("/category/{category}/{keyword}")
+    public ResponseEntity<List<InterviewContentAdminResponseDto>> getInterviewsByCategoryAndKeyword(
+            @Parameter(description = "조회할 카테고리", example = "DATABASE")
+            @PathVariable("category") InterviewCategory category,
+            @Parameter(description = "조회할 키워드", example = "sequence")
+            @PathVariable("keyword") String keyword) {
+        return ResponseEntity.ok(interviewAdminService.getInterviewsByCategoryAndKeyword(category, keyword));
+    }
+
+}

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/controller/InterviewAdminController.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/controller/InterviewAdminController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -31,22 +32,26 @@ public class InterviewAdminController {
     }
 
     @Operation(summary = "특정 카테고리의 모든 질문 조회", description = "선택한 카테고리에 속하는 모든 면접 질문 데이터를 조회합니다.")
-    @GetMapping("/category/{Category}")
-    public ResponseEntity<List<InterviewContentAdminResponseDto>> getInterviewsByCategory(
+    @GetMapping("/category/{category}")
+    public ResponseEntity<Page<InterviewContentAdminResponseDto>> getInterviewsByCategory(
             @Parameter(description = "조회할 카테고리", example = "DATABASE")
-            @PathVariable("Category") InterviewCategory category) {
-        return ResponseEntity.ok(interviewAdminService.getInterviewsByCategory(category));
+            @PathVariable("category") InterviewCategory category,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return ResponseEntity.ok(interviewAdminService.getInterviewsByCategory(category, page, size));
     }
 
     @Operation(summary = "특정 카테고리의 키워드에 해당하는 모든 질문 조회",
             description = "선택한 카테고리 내에서 특정 키워드를 포함하는 면접 질문을 조회합니다.")
     @GetMapping("/category/{category}/{keyword}")
-    public ResponseEntity<List<InterviewContentAdminResponseDto>> getInterviewsByCategoryAndKeyword(
+    public ResponseEntity<Page<InterviewContentAdminResponseDto>> getInterviewsByCategoryAndKeyword(
             @Parameter(description = "조회할 카테고리", example = "DATABASE")
             @PathVariable("category") InterviewCategory category,
             @Parameter(description = "조회할 키워드", example = "sequence")
-            @PathVariable("keyword") String keyword) {
-        return ResponseEntity.ok(interviewAdminService.getInterviewsByCategoryAndKeyword(category, keyword));
+            @PathVariable("keyword") String keyword,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return ResponseEntity.ok(interviewAdminService.getInterviewsByCategoryAndKeyword(category, keyword, page, size));
     }
 
     @Operation(summary = "특정 면접 질문 ID 조회", description = "면접 질문 ID를 이용하여 해당 데이터를 조회합니다.")

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/controller/InterviewAdminController.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/controller/InterviewAdminController.java
@@ -1,6 +1,7 @@
 package com.java.NBE4_5_1_7.domain.interview.controller;
 
 import com.java.NBE4_5_1_7.domain.interview.entity.InterviewCategory;
+import com.java.NBE4_5_1_7.domain.interview.entity.dto.request.InterviewContentAdminRequestDto;
 import com.java.NBE4_5_1_7.domain.interview.entity.dto.response.InterviewContentAdminResponseDto;
 import com.java.NBE4_5_1_7.domain.interview.service.InterviewAdminService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,10 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;
@@ -65,5 +63,13 @@ public class InterviewAdminController {
             @Parameter(description = "조회할 면접 질문 ID", example = "1")
             @PathVariable Long interviewContentId) {
         return ResponseEntity.ok(interviewAdminService.getInterviewContentWithAllTails(interviewContentId));
+    }
+
+    @Operation(summary = "특정 면접 질문 수정", description = "면접 질문 ID를 기준으로 카테고리, 키워드, 질문, 모범 답안을 수정합니다.")
+    @PutMapping("/{interviewContentId}")
+    public ResponseEntity<InterviewContentAdminResponseDto> updateInterviewContent(
+            @PathVariable Long interviewContentId,
+            @RequestBody InterviewContentAdminRequestDto requestDto) {
+        return ResponseEntity.ok(interviewAdminService.updateInterviewContent(interviewContentId, requestDto));
     }
 }

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/controller/InterviewAdminController.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/controller/InterviewAdminController.java
@@ -72,4 +72,12 @@ public class InterviewAdminController {
             @RequestBody InterviewContentAdminRequestDto requestDto) {
         return ResponseEntity.ok(interviewAdminService.updateInterviewContent(interviewContentId, requestDto));
     }
+
+    @Operation(summary = "특정 면접 질문 삭제", description = "면접 질문 ID를 기준으로 해당 질문과 모든 꼬리 질문을 삭제합니다.")
+    @DeleteMapping("/{interviewContentId}")
+    public ResponseEntity<Void> deleteInterviewContent(
+            @PathVariable Long interviewContentId) {
+        interviewAdminService.deleteInterviewContentWithAllTails(interviewContentId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/controller/InterviewAdminController.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/controller/InterviewAdminController.java
@@ -20,7 +20,7 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/admin/interview")
 @RequiredArgsConstructor
-@PreAuthorize("hasRole('ADMIN')")
+@PreAuthorize("hasAuthority('ROLE_ADMIN')")
 public class InterviewAdminController {
 
     private final InterviewAdminService interviewAdminService;

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/controller/InterviewAdminController.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/controller/InterviewAdminController.java
@@ -9,7 +9,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import java.util.Map;
@@ -22,6 +25,7 @@ import java.util.Map;
 public class InterviewAdminController {
 
     private final InterviewAdminService interviewAdminService;
+
     @Operation(summary = "카테고리별 키워드 조회", description = "각 카테고리 내 키워드 목록을 조회합니다.")
     @GetMapping("/all")
     public ResponseEntity<Map<String, List<String>>> getCategoryKeywords() {
@@ -47,4 +51,11 @@ public class InterviewAdminController {
         return ResponseEntity.ok(interviewAdminService.getInterviewsByCategoryAndKeyword(category, keyword));
     }
 
+    @Operation(summary = "특정 면접 질문 ID 조회", description = "면접 질문 ID를 이용하여 해당 데이터를 조회합니다.")
+    @GetMapping("/{interviewContentId}")
+    public ResponseEntity<InterviewContentAdminResponseDto> getInterviewContentById(
+            @Parameter(description = "조회할 면접 질문 ID", example = "1")
+            @PathVariable("interviewContentId") Long interviewContentId) {
+        return ResponseEntity.ok(interviewAdminService.getInterviewContentById(interviewContentId));
+    }
 }

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/controller/InterviewAdminController.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/controller/InterviewAdminController.java
@@ -58,4 +58,12 @@ public class InterviewAdminController {
             @PathVariable("interviewContentId") Long interviewContentId) {
         return ResponseEntity.ok(interviewAdminService.getInterviewContentById(interviewContentId));
     }
+
+    @Operation(summary = "연관된 면접 질문 조회", description = "특정 면접 질문 ID를 기준으로 관련된 모든 꼬리 질문을 조회합니다.")
+    @GetMapping("/{interviewContentId}/related")
+    public ResponseEntity<List<InterviewContentAdminResponseDto>> getRelatedInterviewContents(
+            @Parameter(description = "조회할 면접 질문 ID", example = "1")
+            @PathVariable Long interviewContentId) {
+        return ResponseEntity.ok(interviewAdminService.getInterviewContentWithAllTails(interviewContentId));
+    }
 }

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/entity/InterviewContent.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/entity/InterviewContent.java
@@ -39,4 +39,13 @@ public class InterviewContent {
 
     @OneToMany(mappedBy = "interviewContent", cascade = CascadeType.ALL)
     private List<InterviewContentBookmark> bookmarks = new ArrayList<>();
+
+    public Long getHeadId() {
+        return head_id;
+    }
+
+    public void disconnectTail() {
+        this.tail_id = null;
+        this.hasTail = false;
+    }
 }

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/entity/InterviewContent.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/entity/InterviewContent.java
@@ -2,11 +2,13 @@ package com.java.NBE4_5_1_7.domain.interview.entity;
 
 import jakarta.persistence.*;
 import lombok.Data;
+import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Getter
 @Data
 public class InterviewContent {
     @Id

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/entity/dto/request/InterviewContentAdminRequestDto.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/entity/dto/request/InterviewContentAdminRequestDto.java
@@ -1,0 +1,18 @@
+package com.java.NBE4_5_1_7.domain.interview.entity.dto.request;
+
+import com.java.NBE4_5_1_7.domain.interview.entity.InterviewCategory;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class InterviewContentAdminRequestDto {
+    private Long headId;
+    private Long tailId;
+    private boolean isHead;
+    private boolean hasTail;
+    private String keyword;
+    private InterviewCategory category;
+    private String question;
+    private String modelAnswer;
+}

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/entity/dto/response/InterviewContentAdminResponseDto.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/entity/dto/response/InterviewContentAdminResponseDto.java
@@ -1,0 +1,34 @@
+package com.java.NBE4_5_1_7.domain.interview.entity.dto.response;
+
+import com.java.NBE4_5_1_7.domain.interview.entity.InterviewCategory;
+import com.java.NBE4_5_1_7.domain.interview.entity.InterviewContent;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class InterviewContentAdminResponseDto {
+    private Long id;
+    private Long headId;
+    private Long tailId;
+    private boolean isHead;
+    private boolean hasTail;
+    private String keyword;
+    private InterviewCategory category;
+    private String question;
+    private String modelAnswer;
+    private Long likeCount;
+
+    public InterviewContentAdminResponseDto(InterviewContent content, Long likeCount) {
+        this.id = content.getInterview_content_id();
+        this.headId = content.getHead_id();
+        this.tailId = content.getTail_id();
+        this.isHead = content.isHead();
+        this.hasTail = content.isHasTail();
+        this.keyword = content.getKeyword();
+        this.category = content.getCategory();
+        this.question = content.getQuestion();
+        this.modelAnswer = content.getModelAnswer();
+        this.likeCount = likeCount;
+    }
+}

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/repository/InterviewContentAdminRepository.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/repository/InterviewContentAdminRepository.java
@@ -1,0 +1,31 @@
+package com.java.NBE4_5_1_7.domain.interview.repository;
+
+import com.java.NBE4_5_1_7.domain.interview.entity.InterviewCategory;
+import com.java.NBE4_5_1_7.domain.interview.entity.InterviewContent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface InterviewContentAdminRepository extends JpaRepository<InterviewContent, Long> {
+    // 카테고리 목록 조회
+    @Query("select distinct ic.category from InterviewContent ic")
+    List<InterviewCategory> findUniqueCategories();
+
+    // 특정 카테고리의 키워드 목록 조회
+    @Query("select distinct ic.keyword from InterviewContent ic where ic.category = :category")
+    List<String> findUniqueKeywordsByCategory(@Param("category") InterviewCategory category);
+
+    // 특정 카테고리에 속한 모든 면접 질문 조회
+    @Query("select ic from InterviewContent ic where ic.category = :category")
+    List<InterviewContent> findByCategory(@Param("category") InterviewCategory category);
+
+    // 특정 질문의 좋아요 개수 조회
+    @Query("SELECT COUNT(icl) FROM InterviewContentLike icl WHERE icl.interviewContent.id = :interviewContentId")
+    Long countLikesByInterviewContentId(@Param("interviewContentId") Long interviewContentId);
+
+    // 특정 카테고리 & 키워드를 포함하는 질문 조회
+    @Query("SELECT ic FROM InterviewContent ic WHERE ic.category = :category AND ic.keyword = :keyword")
+    List<InterviewContent> findByCategoryAndKeyword(@Param("category") InterviewCategory category, @Param("keyword") String keyword);
+}

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/repository/InterviewContentAdminRepository.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/repository/InterviewContentAdminRepository.java
@@ -22,7 +22,7 @@ public interface InterviewContentAdminRepository extends JpaRepository<Interview
     List<InterviewContent> findByCategory(@Param("category") InterviewCategory category);
 
     // 특정 질문의 좋아요 개수 조회
-    @Query("SELECT COUNT(icl) FROM InterviewContentLike icl WHERE icl.interviewContent.id = :interviewContentId")
+    @Query("SELECT COUNT(icl) FROM InterviewContentLike icl WHERE icl.interviewContent.interview_content_id = :interviewContentId")
     Long countLikesByInterviewContentId(@Param("interviewContentId") Long interviewContentId);
 
     // 특정 카테고리 & 키워드를 포함하는 질문 조회

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/repository/InterviewContentAdminRepository.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/repository/InterviewContentAdminRepository.java
@@ -2,6 +2,8 @@ package com.java.NBE4_5_1_7.domain.interview.repository;
 
 import com.java.NBE4_5_1_7.domain.interview.entity.InterviewCategory;
 import com.java.NBE4_5_1_7.domain.interview.entity.InterviewContent;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,7 +21,7 @@ public interface InterviewContentAdminRepository extends JpaRepository<Interview
 
     // 특정 카테고리에 속한 모든 면접 질문 조회
     @Query("select ic from InterviewContent ic where ic.category = :category")
-    List<InterviewContent> findByCategory(@Param("category") InterviewCategory category);
+    Page<InterviewContent> findByCategory(@Param("category") InterviewCategory category, Pageable pageable);
 
     // 특정 질문의 좋아요 개수 조회
     @Query("SELECT COUNT(icl) FROM InterviewContentLike icl WHERE icl.interviewContent.interview_content_id = :interviewContentId")
@@ -27,7 +29,7 @@ public interface InterviewContentAdminRepository extends JpaRepository<Interview
 
     // 특정 카테고리 & 키워드를 포함하는 질문 조회
     @Query("SELECT ic FROM InterviewContent ic WHERE ic.category = :category AND ic.keyword = :keyword")
-    List<InterviewContent> findByCategoryAndKeyword(@Param("category") InterviewCategory category, @Param("keyword") String keyword);
+    Page<InterviewContent> findByCategoryAndKeyword(@Param("category") InterviewCategory category, @Param("keyword") String keyword, Pageable pageable);
 
     // 주어진 head_id를 기준으로 해당 질문과 연결된 모든 후속(꼬리) 질문을 조회
     @Query("SELECT ic FROM InterviewContent ic WHERE ic.head_id = :id")

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/repository/InterviewContentAdminRepository.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/repository/InterviewContentAdminRepository.java
@@ -28,4 +28,8 @@ public interface InterviewContentAdminRepository extends JpaRepository<Interview
     // 특정 카테고리 & 키워드를 포함하는 질문 조회
     @Query("SELECT ic FROM InterviewContent ic WHERE ic.category = :category AND ic.keyword = :keyword")
     List<InterviewContent> findByCategoryAndKeyword(@Param("category") InterviewCategory category, @Param("keyword") String keyword);
+
+    // 주어진 head_id를 기준으로 해당 질문과 연결된 모든 후속(꼬리) 질문을 조회
+    @Query("SELECT ic FROM InterviewContent ic WHERE ic.head_id = :id")
+    List<InterviewContent> findRelatedQuestions(@Param("id") Long id);
 }

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/service/InterviewAdminService.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/service/InterviewAdminService.java
@@ -124,7 +124,8 @@ public class InterviewAdminService {
 
         interviewContentAdminRepository.save(content);
 
-        return new InterviewContentAdminResponseDto(content, 0L);
+        Long likeCount = interviewContentAdminRepository.countLikesByInterviewContentId(content.getInterview_content_id());
+        return new InterviewContentAdminResponseDto(content, likeCount);
     }
 
     // 특정 면접 질문과 모든 꼬리 질문을 삭제

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/service/InterviewAdminService.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/service/InterviewAdminService.java
@@ -68,4 +68,12 @@ public class InterviewAdminService {
                 })
                 .collect(Collectors.toList());
     }
+
+    // 특정 면접 질문 ID 조회
+    public InterviewContentAdminResponseDto getInterviewContentById(Long interviewContentId) {
+        InterviewContent content = interviewContentAdminRepository.findById(interviewContentId)
+                .orElseThrow(() -> new ServiceException("404", "해당 ID의 면접 질문을 찾을 수 없습니다."));
+        Long likeCount = interviewContentAdminRepository.countLikesByInterviewContentId(content.getInterview_content_id());
+        return new InterviewContentAdminResponseDto(content, likeCount);
+    }
 }

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/service/InterviewAdminService.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/service/InterviewAdminService.java
@@ -8,6 +8,9 @@ import com.java.NBE4_5_1_7.domain.interview.repository.InterviewContentAdminRepo
 import com.java.NBE4_5_1_7.global.exception.ServiceException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -41,35 +44,33 @@ public class InterviewAdminService {
     }
 
     // 특정 카테고리의 모든 면접 질문 조회
-    public List<InterviewContentAdminResponseDto> getInterviewsByCategory(InterviewCategory category) {
-        List<InterviewContent> contents = interviewContentAdminRepository.findByCategory(category);
+    public Page<InterviewContentAdminResponseDto> getInterviewsByCategory(InterviewCategory category, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<InterviewContent> contents = interviewContentAdminRepository.findByCategory(category, pageable);
 
         if (contents.isEmpty()) {
             throw new ServiceException("404", "해당 카테고리에 속하는 면접 질문이 없습니다.");
         }
 
-        return contents.stream()
-                .map(content -> {
-                    Long likeCount = interviewContentAdminRepository.countLikesByInterviewContentId(content.getInterview_content_id());
-                    return new InterviewContentAdminResponseDto(content, likeCount);
-                })
-                .collect(Collectors.toList());
+        return contents.map(content -> {
+            Long likeCount = interviewContentAdminRepository.countLikesByInterviewContentId(content.getInterview_content_id());
+            return new InterviewContentAdminResponseDto(content, likeCount);
+        });
     }
 
     // 특정 카테고리와 키워드를 포함하는 면접 질문 조회
-    public List<InterviewContentAdminResponseDto> getInterviewsByCategoryAndKeyword(InterviewCategory category, String keyword) {
-        List<InterviewContent> contents = interviewContentAdminRepository.findByCategoryAndKeyword(category, keyword);
+    public Page<InterviewContentAdminResponseDto> getInterviewsByCategoryAndKeyword(InterviewCategory category, String keyword, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<InterviewContent> contents = interviewContentAdminRepository.findByCategoryAndKeyword(category, keyword, pageable);
 
         if (contents.isEmpty()) {
             throw new ServiceException("404", "해당 카테고리와 키워드를 포함하는 면접 질문이 없습니다.");
         }
 
-        return contents.stream()
-                .map(content -> {
-                    Long likeCount = interviewContentAdminRepository.countLikesByInterviewContentId(content.getInterview_content_id());
-                    return new InterviewContentAdminResponseDto(content, likeCount);
-                })
-                .collect(Collectors.toList());
+        return contents.map(content -> {
+            Long likeCount = interviewContentAdminRepository.countLikesByInterviewContentId(content.getInterview_content_id());
+            return new InterviewContentAdminResponseDto(content, likeCount);
+        });
     }
 
     // 특정 면접 질문 ID 조회

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/service/InterviewAdminService.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/service/InterviewAdminService.java
@@ -1,0 +1,71 @@
+package com.java.NBE4_5_1_7.domain.interview.service;
+
+import com.java.NBE4_5_1_7.domain.interview.entity.InterviewCategory;
+import com.java.NBE4_5_1_7.domain.interview.entity.InterviewContent;
+import com.java.NBE4_5_1_7.domain.interview.entity.dto.response.InterviewContentAdminResponseDto;
+import com.java.NBE4_5_1_7.domain.interview.repository.InterviewContentAdminRepository;
+import com.java.NBE4_5_1_7.global.exception.ServiceException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class InterviewAdminService {
+
+    private final InterviewContentAdminRepository interviewContentAdminRepository;
+
+    // 카테고리별 키워드 목록 조회
+    public Map<String, List<String>> getCategoryKeywords() {
+        Map<String, List<String>> categoryKeywords = new HashMap<>();
+        List<InterviewCategory> categories = interviewContentAdminRepository.findUniqueCategories();
+
+        if (categories.isEmpty()) {
+            throw new ServiceException("404", "등록된 면접 질문 카테고리가 없습니다.");
+        }
+
+        for (InterviewCategory category : categories) {
+            String categoryName = category.name();
+            List<String> keywords = interviewContentAdminRepository.findUniqueKeywordsByCategory(category);
+            categoryKeywords.put(categoryName, keywords);
+        }
+
+        return categoryKeywords;
+    }
+
+    // 특정 카테고리의 모든 면접 질문 조회
+    public List<InterviewContentAdminResponseDto> getInterviewsByCategory(InterviewCategory category) {
+        List<InterviewContent> contents = interviewContentAdminRepository.findByCategory(category);
+
+        if (contents.isEmpty()) {
+            throw new ServiceException("404", "해당 카테고리에 속하는 면접 질문이 없습니다.");
+        }
+
+        return contents.stream()
+                .map(content -> {
+                    Long likeCount = interviewContentAdminRepository.countLikesByInterviewContentId(content.getInterview_content_id());
+                    return new InterviewContentAdminResponseDto(content, likeCount);
+                })
+                .collect(Collectors.toList());
+    }
+
+    // 특정 카테고리와 키워드를 포함하는 면접 질문 조회
+    public List<InterviewContentAdminResponseDto> getInterviewsByCategoryAndKeyword(InterviewCategory category, String keyword) {
+        List<InterviewContent> contents = interviewContentAdminRepository.findByCategoryAndKeyword(category, keyword);
+
+        if (contents.isEmpty()) {
+            throw new ServiceException("404", "해당 카테고리와 키워드를 포함하는 면접 질문이 없습니다.");
+        }
+
+        return contents.stream()
+                .map(content -> {
+                    Long likeCount = interviewContentAdminRepository.countLikesByInterviewContentId(content.getInterview_content_id());
+                    return new InterviewContentAdminResponseDto(content, likeCount);
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/service/InterviewAdminService.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/service/InterviewAdminService.java
@@ -2,6 +2,7 @@ package com.java.NBE4_5_1_7.domain.interview.service;
 
 import com.java.NBE4_5_1_7.domain.interview.entity.InterviewCategory;
 import com.java.NBE4_5_1_7.domain.interview.entity.InterviewContent;
+import com.java.NBE4_5_1_7.domain.interview.entity.dto.request.InterviewContentAdminRequestDto;
 import com.java.NBE4_5_1_7.domain.interview.entity.dto.response.InterviewContentAdminResponseDto;
 import com.java.NBE4_5_1_7.domain.interview.repository.InterviewContentAdminRepository;
 import com.java.NBE4_5_1_7.global.exception.ServiceException;
@@ -108,5 +109,21 @@ public class InterviewAdminService {
             }
         }
         return result;
+    }
+
+    // 면접 질문 ID를 기준으로 카테고리, 키워드, 질문, 모범 답안을 수정
+    @Transactional
+    public InterviewContentAdminResponseDto updateInterviewContent(Long interviewContentId, InterviewContentAdminRequestDto requestDto) {
+        InterviewContent content = interviewContentAdminRepository.findById(interviewContentId)
+                .orElseThrow(() -> new ServiceException("404", "해당 ID의 면접 질문을 찾을 수 없습니다."));
+
+        content.setCategory(requestDto.getCategory());
+        content.setKeyword(requestDto.getKeyword());
+        content.setQuestion(requestDto.getQuestion());
+        content.setModelAnswer(requestDto.getModelAnswer());
+
+        interviewContentAdminRepository.save(content);
+
+        return new InterviewContentAdminResponseDto(content, 0L);
     }
 }

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/service/InterviewAdminService.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/interview/service/InterviewAdminService.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -135,9 +134,17 @@ public class InterviewAdminService {
         InterviewContent content = interviewContentAdminRepository.findById(interviewContentId)
                 .orElseThrow(() -> new ServiceException("404", "해당 ID의 면접 질문을 찾을 수 없습니다."));
 
+        Long headId = content.getHeadId();
         List<InterviewContent> relatedQuestions = getTailContents(content.getInterview_content_id());
 
-        // 모든 연관된 질문 삭제
+        if (headId != null) {
+            InterviewContent headQuestion = interviewContentAdminRepository.findById(headId).orElse(null);
+            if (headQuestion != null) {
+                headQuestion.disconnectTail();
+                interviewContentAdminRepository.save(headQuestion);
+            }
+        }
+
         interviewContentAdminRepository.deleteAll(relatedQuestions);
         interviewContentAdminRepository.delete(content);
     }

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/study/controller/StudyContentAdminController.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/study/controller/StudyContentAdminController.java
@@ -8,8 +8,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -18,21 +16,18 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/admin/study")
 @RequiredArgsConstructor
+@PreAuthorize("hasAuthority('ROLE_ADMIN')")
 public class StudyContentAdminController {
 
     private final StudyContentAdminService studyContentAdminService;
 
     // 모든 카테고리 (첫 번째 카테고리 + 두 번째 카테고리) 조회
-    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     @GetMapping("/all")
     public ResponseEntity<Map<String, List<String>>> getAllCategory() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        System.out.println("Current authorities: " + auth.getAuthorities());
         return ResponseEntity.ok(studyContentAdminService.getAllCategory());
     }
 
     // 첫 번째 카테고리에 해당하는 학습 콘텐츠 조회
-    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     @GetMapping("/category/{firstCategory}")
     public ResponseEntity<Page<StudyContentDetailDto>> getPagedStudyContentsByFirstCategory(@PathVariable String firstCategory, @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
 
@@ -42,7 +37,6 @@ public class StudyContentAdminController {
     }
 
     // 첫 번째 + 두 번째 카테고리에 해당하는 학습 콘텐츠 조회
-    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     @GetMapping("/category/{firstCategory}/{secondCategory}")
     public ResponseEntity<Page<StudyContentDetailDto>> getPagedStudyContentsByCategories(@PathVariable String firstCategory, @PathVariable String secondCategory, @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
 
@@ -52,14 +46,12 @@ public class StudyContentAdminController {
     }
 
     // 학습 콘텐츠 조회
-    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     @GetMapping("/{studyContentId}")
     public ResponseEntity<StudyContentDetailDto> getStudyContentById(@PathVariable Long studyContentId) {
         return ResponseEntity.ok(studyContentAdminService.getStudyContentById(studyContentId));
     }
 
     // 학습 콘텐츠 수정
-    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     @PutMapping("/{studyContentId}")
     public ResponseEntity<String> updateStudyContent(@PathVariable Long studyContentId, @RequestBody StudyContentUpdateRequestDto requestDto) {
         studyContentAdminService.updateStudyContent(studyContentId, requestDto);
@@ -67,7 +59,6 @@ public class StudyContentAdminController {
     }
 
     // 학습 콘텐츠 삭제
-    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     @DeleteMapping("/{studyContentId}")
     public ResponseEntity<String> deleteStudyContent(@PathVariable Long studyContentId) {
         studyContentAdminService.deleteStudyContent(studyContentId);

--- a/backend/src/main/java/com/java/NBE4_5_1_7/domain/study/service/StudyContentAdminService.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_7/domain/study/service/StudyContentAdminService.java
@@ -66,7 +66,7 @@ public class StudyContentAdminService {
         Page<StudyContent> studyContents = studyContentRepository.findByFirstCategoryAndSecondCategory(category, secondCategory, pageable);
 
         if (studyContents.isEmpty()) {
-            throw new ServiceException("404", "해당 카테고리 조합에 학습 콘텐츠가 존재하지 않습니다.");
+            throw new ServiceException("404", "해당 카테고리 조합에 학습 콘텐츠가 존재하지 않습니다." + firstCategory + secondCategory);
         }
 
         return studyContents.map(StudyContentDetailDto::new);

--- a/frontend/src/app/admin/interview/content.tsx
+++ b/frontend/src/app/admin/interview/content.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import styles from "../../styles/admin/content.module.css";
+import InterviewDetailModal from "./modal/interviewDetailModal";
+import InterviewEditModal from "./modal/interviewEditModal";
+import InterviewDeleteModal from "./modal/interviewDeleteModal";
+
+const API_URL = "http://localhost:8080/api/v1/admin/interview";
+
+interface InterviewContentDetail {
+  id: number;
+  headId: number | null;
+  tailId: number | null;
+  isHead: boolean;
+  hasTail: boolean;
+  keyword: string;
+  category: string;
+  question: string;
+  modelAnswer: string;
+  likeCount: number;
+}
+
+interface ContentProps {
+  selectedCategory: string | null;
+  selectedKeyword: string | null;
+}
+
+export default function Content({ selectedCategory, selectedKeyword }: ContentProps) {
+  const [interviewContents, setInterviewContents] = useState<InterviewContentDetail[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [pageSize, setPageSize] = useState(6);
+  const [totalPages, setTotalPages] = useState(1);
+  const [selectedInterview, setSelectedInterview] = useState<InterviewContentDetail | null>(null);
+  const [editInterview, setEditInterview] = useState<InterviewContentDetail | null>(null);
+  const [deleteInterview, setDeleteInterview] = useState<InterviewContentDetail | null>(null);
+
+  useEffect(() => {
+    if (!selectedCategory) return;
+
+    let url = `${API_URL}/category/${encodeURIComponent(selectedCategory)}`;
+    if (selectedKeyword) {
+      url += `/${encodeURIComponent(selectedKeyword)}`;
+    }
+    url += `?page=${currentPage}&size=${pageSize}`;
+
+    fetch(url, {
+      method: "GET",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error("면접 질문을 불러오는 데 실패했습니다.");
+        return res.json();
+      })
+      .then((data) => {
+        console.log("Fetched Data:", data);
+        setInterviewContents(data.content as InterviewContentDetail[]);
+        setTotalPages(data.totalPages);
+      })
+      .catch((err) => {
+        console.error("Error fetching interview content:", err);
+        setError(err.message);
+      });
+  }, [selectedCategory, selectedKeyword, currentPage, pageSize]);
+
+  const handleUpdateInterview = (updatedInterview: InterviewContentDetail) => {
+    setInterviewContents((prevContents) =>
+      prevContents.map((content) =>
+        content.id === updatedInterview.id ? updatedInterview : content
+      )
+    );
+    setSelectedInterview(null);
+  };
+
+  const handleDeleteInterview = (interviewId: number) => {
+    setInterviewContents((prevContents) => prevContents.filter((content) => content.id !== interviewId));
+    setDeleteInterview(null);
+  };
+
+  return (
+    <main className={styles.contentContainer}>
+      {error && <p style={{ color: "red" }}>{error}</p>}
+      <ul className={styles.contentList}>
+        {interviewContents.length > 0 ? (
+          interviewContents.map((content) => (
+            <li key={content.id} className={styles.contentItem}>
+              <div className={styles.titleContainer}>
+                <span>{content.question}</span>
+                <span className={styles.subTitle}>{content.keyword}</span>
+              </div>
+
+              <div className={styles.buttonGroup}>
+                <button className={styles.detailButton} onClick={() => setSelectedInterview(content)}>
+                  상세 보기
+                </button>
+                <button className={styles.editButton} onClick={() => setEditInterview(content)}>
+                  수정
+                </button>
+                <button className={styles.deleteButton} onClick={() => setDeleteInterview(content)}>
+                  삭제
+                </button>
+              </div>
+            </li>
+          ))
+        ) : (
+          <p>면접 질문이 없습니다.</p>
+        )}
+      </ul>
+
+      <div className={styles.pagination}>
+        <button onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 0))} disabled={currentPage === 0}>
+          ⬅
+        </button>
+        <span>{currentPage + 1} / {totalPages}</span>
+        <button onClick={() => setCurrentPage((prev) => (prev < totalPages - 1 ? prev + 1 : prev))} disabled={currentPage === totalPages - 1}>
+          ➡
+        </button>
+      </div>
+
+      {selectedInterview && (
+        <InterviewDetailModal
+          interview={selectedInterview}
+          onClose={() => setSelectedInterview(null)}
+          onSelectInterview={(newInterview: any) => {
+            if (!newInterview) return;
+
+            // InterviewContentAdminResponseDto 타입의 데이터 처리
+            const formattedInterview: InterviewContentDetail = {
+              id: newInterview.id,
+              headId: newInterview.headId ?? null,
+              tailId: newInterview.tailId ?? null,
+              isHead: newInterview.isHead ?? false,
+              hasTail: newInterview.hasTail ?? false,
+              keyword: newInterview.keyword ?? "",
+              category: newInterview.category ?? "",
+              question: newInterview.question ?? "",
+              modelAnswer: newInterview.modelAnswer ?? "",
+              likeCount: newInterview.likeCount ?? 0,
+            };
+
+            setSelectedInterview(formattedInterview);
+          }}
+
+        />
+      )}
+
+      {editInterview && (
+        <InterviewEditModal
+          interview={editInterview}
+          onClose={() => setEditInterview(null)}
+          onUpdate={handleUpdateInterview}
+        />
+      )}
+
+      {deleteInterview && (
+        <InterviewDeleteModal interview={deleteInterview} onClose={() => setDeleteInterview(null)} onDelete={handleDeleteInterview} />
+      )}
+    </main>
+  );
+}

--- a/frontend/src/app/admin/interview/modal/interviewDeleteModal.tsx
+++ b/frontend/src/app/admin/interview/modal/interviewDeleteModal.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import styles from "../../../styles/admin/modal/contentDeleteModal.module.css";
+
+const API_URL = "http://localhost:8080/api/v1/admin/interview";
+
+interface InterviewDeleteModalProps {
+    interview: { id: number; question: string };
+    onClose: () => void;
+    onDelete: (interviewId: number) => void;
+}
+
+export default function InterviewDeleteModal({ interview, onClose, onDelete }: InterviewDeleteModalProps) {
+    const handleDelete = async () => {
+        try {
+            console.log(`삭제 요청: ${API_URL}/${interview.id}`);
+
+            const response = await fetch(`${API_URL}/${interview.id}`, {
+                method: "DELETE",
+                credentials: "include",
+                headers: { "Content-Type": "application/json" },
+            });
+
+            if (!response.ok) {
+                throw new Error(`삭제 실패: ${response.status}`);
+            }
+
+            onDelete(interview.id);
+            onClose();
+        } catch (error: any) {
+            console.error("삭제 오류:", error);
+            alert(`삭제 중 오류가 발생했습니다: ${error.message}`);
+        }
+    };
+
+    return (
+        <div className={styles.modalOverlay}>
+            <div className={styles.modalContent}>
+                <h2>삭제 확인</h2>
+                <p>
+                    "{interview.question}"을(를) 삭제하시겠습니까?
+                </p>
+                <div className={styles.buttonGroup}>
+                    <button onClick={handleDelete} className={styles.deleteButton}>
+                        삭제
+                    </button>
+                    <button onClick={onClose} className={styles.cancelButton}>
+                        취소
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/app/admin/interview/modal/interviewDetailModal.tsx
+++ b/frontend/src/app/admin/interview/modal/interviewDetailModal.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import styles from "../../../styles/admin/modal/contentDetailModal.module.css";
+
+const API_URL = "http://localhost:8080/api/v1/admin/interview";
+
+interface InterviewContent {
+    id: number;
+    question: string;
+    category: string;
+    keyword: string;
+    modelAnswer: string;
+}
+
+interface InterviewDetailModalProps {
+    interview: InterviewContent;
+    onClose: () => void;
+    onSelectInterview: (selectedInterview: InterviewContent) => void;
+}
+
+const InterviewDetailModal: React.FC<InterviewDetailModalProps> = ({ interview, onClose, onSelectInterview }) => {
+    const [relatedQuestions, setRelatedQuestions] = useState<InterviewContent[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [historyStack, setHistoryStack] = useState<InterviewContent[]>([]);
+
+    useEffect(() => {
+        const fetchRelatedQuestions = async () => {
+            try {
+                const response = await fetch(`${API_URL}/${interview.id}/related`, {
+                    method: "GET",
+                    credentials: "include",
+                    headers: { "Content-Type": "application/json" },
+                });
+
+                if (!response.ok) {
+                    throw new Error("꼬리 질문을 불러오는 데 실패했습니다.");
+                }
+
+                const data: InterviewContent[] = await response.json();
+                console.log("Fetched Related Questions:", data);
+
+                const filteredQuestions = data.filter(q => q.id !== interview.id);
+                setRelatedQuestions(filteredQuestions);
+            } catch (err: any) {
+                setError(err.message);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchRelatedQuestions();
+    }, [interview.id]);
+
+    const handleRelatedQuestionClick = async (questionId: number) => {
+        try {
+            const response = await fetch(`${API_URL}/${questionId}`, {
+                method: "GET",
+                credentials: "include",
+                headers: { "Content-Type": "application/json" },
+            });
+
+            if (!response.ok) {
+                throw new Error("질문 데이터를 불러오는 데 실패했습니다.");
+            }
+
+            const newInterview: InterviewContent = await response.json();
+            console.log("New Selected Interview:", newInterview);
+
+            setHistoryStack((prevStack) => [...prevStack, interview]);
+            onSelectInterview(newInterview);
+        } catch (err) {
+            console.error("Error fetching new interview:", err);
+        }
+    };
+
+    const handleGoBack = () => {
+        if (historyStack.length > 0) {
+            const previousInterview = historyStack[historyStack.length - 1];
+            setHistoryStack((prevStack) => prevStack.slice(0, -1));
+            onSelectInterview(previousInterview);
+        }
+    };
+
+    return (
+        <div className={styles.modalOverlay}>
+            <div className={styles.modalContent}>
+                <h2 className={styles.modalTitle}>{interview.question}</h2>
+                <p className={styles.modalCategory}>{interview.category} / {interview.keyword}</p>
+                <p className={styles.modalBody}>{interview.modelAnswer}</p>
+
+                <h3 className={styles.relatedTitle}>연관된 꼬리 질문</h3>
+                {loading ? (
+                    <p>로딩 중...</p>
+                ) : error ? (
+                    <p className={styles.error}>{error}</p>
+                ) : relatedQuestions.length > 0 ? (
+                    <ul className={styles.relatedList}>
+                        {relatedQuestions.map((q) => (
+                            <li
+                                key={q.id}
+                                className={styles.relatedItem}
+                                onClick={() => handleRelatedQuestionClick(q.id)}
+                            >
+                                {q.question}
+                            </li>
+                        ))}
+                    </ul>
+                ) : (
+                    <p>연관된 꼬리 질문이 없습니다.</p>
+                )}
+
+                <div className={styles.modalFooter}>
+                    <button
+                        className={styles.backButton}
+                        onClick={handleGoBack}
+                        disabled={historyStack.length === 0}
+                    >
+                        뒤로가기
+                    </button>
+
+                    <button className={styles.closeButton} onClick={onClose}>
+                        닫기
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default InterviewDetailModal;

--- a/frontend/src/app/admin/interview/modal/interviewEditModal.tsx
+++ b/frontend/src/app/admin/interview/modal/interviewEditModal.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import styles from "../../../styles/admin/modal/contentEditModal.module.css";
+
+const API_URL = "http://localhost:8080/api/v1/admin/interview";
+
+interface InterviewEditModalProps {
+    interview: {
+        id: number;
+        category: string;
+        keyword: string;
+        question: string;
+        modelAnswer: string;
+    };
+    onClose: () => void;
+    onUpdate: (updatedInterview: any) => void;
+}
+
+export default function InterviewEditModal({ interview, onClose, onUpdate }: InterviewEditModalProps) {
+    const [category, setCategory] = useState(interview.category);
+    const [keyword, setKeyword] = useState(interview.keyword);
+    const [question, setQuestion] = useState(interview.question);
+    const [modelAnswer, setModelAnswer] = useState(interview.modelAnswer);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [categories, setCategories] = useState<string[]>([]);
+
+    // 기존 카테고리 목록 불러오기
+    useEffect(() => {
+        fetch(`${API_URL}/all`, {
+            method: "GET",
+            credentials: "include",
+            headers: { "Content-Type": "application/json" },
+        })
+            .then(async (res) => {
+                if (!res.ok) {
+                    throw new Error(`서버 오류 발생: ${res.status}`);
+                }
+                return res.json();
+            })
+            .then((data) => {
+                const categoryKeys = Object.keys(data);
+                setCategories(categoryKeys);
+
+                if (!category && categoryKeys.length > 0) {
+                    setCategory(categoryKeys[0]);
+                }
+            })
+            .catch(() => {
+                setError("카테고리를 불러오는 데 실패했습니다.");
+            });
+    }, []);
+
+    const handleSave = async () => {
+        setLoading(true);
+        setError(null);
+
+        const updatedData = {
+            category,
+            keyword,
+            question,
+            modelAnswer
+        };
+
+        try {
+            const response = await fetch(`${API_URL}/${interview.id}`, {
+                method: "PUT",
+                credentials: "include",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(updatedData),
+            });
+
+            let responseData;
+            const responseText = await response.text();
+
+            try {
+                responseData = JSON.parse(responseText);
+            } catch (error) {
+                responseData = responseText;
+            }
+
+            if (!response.ok) {
+                throw new Error(responseData.message || responseData || "수정에 실패했습니다.");
+            }
+
+            const updatedInterview = {
+                ...interview,
+                category,
+                keyword,
+                question,
+                modelAnswer,
+            };
+
+            onUpdate(updatedInterview);
+            onClose();
+        } catch (error: any) {
+            setError(error.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className={styles.modalOverlay}>
+            <div className={styles.modalContent}>
+                <h2>면접 질문 수정</h2>
+                {error && <p className={styles.errorMessage}>{error}</p>}
+
+                <label>카테고리:</label>
+                <select
+                    value={category}
+                    onChange={(e) => setCategory(e.target.value)}
+                    className={styles.selectField}
+                >
+                    {categories.length > 0 ? (
+                        categories.map((cat) => (
+                            <option key={cat} value={cat}>
+                                {cat}
+                            </option>
+                        ))
+                    ) : (
+                        <option disabled>카테고리를 불러오는 중...</option>
+                    )}
+                </select>
+
+                <label>키워드:</label>
+                <input
+                    type="text"
+                    value={keyword}
+                    onChange={(e) => setKeyword(e.target.value)}
+                    className={styles.inputField}
+                />
+
+                <label>질문:</label>
+                <input
+                    type="text"
+                    value={question}
+                    onChange={(e) => setQuestion(e.target.value)}
+                    className={styles.inputField}
+                />
+
+                <label>모범 답안:</label>
+                <textarea
+                    value={modelAnswer}
+                    onChange={(e) => setModelAnswer(e.target.value)}
+                    className={styles.textareaField}
+                    rows={5}
+                />
+
+                <div className={styles.buttonGroup}>
+                    <button onClick={handleSave} disabled={loading} className={styles.saveButton}>
+                        {loading ? "저장 중..." : "저장"}
+                    </button>
+                    <button onClick={onClose} className={styles.cancelButton}>취소</button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/app/admin/interview/page.tsx
+++ b/frontend/src/app/admin/interview/page.tsx
@@ -1,10 +1,26 @@
 "use client";
 
-export default function QuestionsPage() {
+import { useState } from "react";
+import styles from "../../styles/admin/page.module.css";
+import Sidebar from "./sidebar";
+import Content from "./content";
+
+export default function InterviewContentPage() {
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [selectedKeyword, setSelectedKeyword] = useState<string | null>(null);
+
   return (
-    <div>
-      <h1>면접 질문 관리</h1>
-      <p>구현 중.. </p>
+    <div className={styles.adminContainer}>
+      <Sidebar
+        selectedCategory={selectedCategory}
+        setSelectedCategory={setSelectedCategory}
+        selectedKeyword={selectedKeyword}
+        setSelectedKeyword={setSelectedKeyword}
+      />
+      <Content
+        selectedCategory={selectedCategory}
+        selectedKeyword={selectedKeyword}
+      />
     </div>
   );
 }

--- a/frontend/src/app/admin/interview/sidebar.tsx
+++ b/frontend/src/app/admin/interview/sidebar.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import styles from "../../styles/admin/sidebar.module.css";
+
+const API_URL = "http://localhost:8080/api/v1/admin/interview";
+
+interface SidebarProps {
+  selectedCategory: string | null;
+  setSelectedCategory: (category: string) => void;
+  selectedKeyword: string | null;
+  setSelectedKeyword: (keyword: string | null) => void;
+}
+
+export default function Sidebar({
+  selectedCategory,
+  setSelectedCategory,
+  selectedKeyword,
+  setSelectedKeyword,
+}: SidebarProps) {
+  const [categories, setCategories] = useState<{ [key: string]: string[] }>({});
+  const [openCategory, setOpenCategory] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`${API_URL}/all`, {
+      method: "GET",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error("카테고리 목록을 불러오지 못했습니다.");
+        return res.json();
+      })
+      .then((data) => {
+        setCategories(data);
+        const firstCategoryKeys = Object.keys(data);
+        if (firstCategoryKeys.length > 0 && !selectedCategory) {
+          setSelectedCategory(firstCategoryKeys[0]);
+        }
+      })
+      .catch((err) => console.error(err));
+  }, []);
+
+  return (
+    <aside className={styles.sidebar}>
+      <ul className={styles.categoryList}>
+        {Object.keys(categories).map((category) => (
+          <div key={category} className={styles.categoryWrapper}>
+            <li className={styles.categoryItem}>
+              <button
+                className={`${styles.categoryButton} ${category === selectedCategory ? styles.active : ""
+                  }`}
+                onClick={() => {
+                  if (openCategory === category) {
+                    setOpenCategory(null);
+                  } else {
+                    setSelectedCategory(category);
+                    setSelectedKeyword(null);
+                    setOpenCategory(category);
+                  }
+                }}
+              >
+                {category}
+                <span className={styles.arrowIcon}>
+                  {openCategory === category ? "▲" : "▼"}
+                </span>
+              </button>
+            </li>
+            {openCategory === category && categories[category].length > 0 && (
+              <ul className={styles.dropdownMenu}>
+                {categories[category].map((keyword) => (
+                  <li
+                    key={keyword}
+                    className={styles.dropdownItem}
+                    onClick={() => setSelectedKeyword(keyword)}
+                  >
+                    {keyword}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/frontend/src/app/admin/studyContent/modal/contentEditModal.tsx
+++ b/frontend/src/app/admin/studyContent/modal/contentEditModal.tsx
@@ -112,7 +112,7 @@ export default function ContentEditModal({ content, onClose, onUpdate }: Content
   return (
     <div className={styles.modalOverlay}>
       <div className={styles.modalContent}>
-        <h2>콘텐츠 수정</h2>
+        <h2>학습 콘텐츠 수정</h2>
 
         {error && <p className={styles.errorMessage}>{error}</p>}
 

--- a/frontend/src/app/styles/admin/content.module.css
+++ b/frontend/src/app/styles/admin/content.module.css
@@ -21,15 +21,19 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  flex-wrap: nowrap;
 }
 
-/* 콘텐츠 제목 스타일 */
 .titleContainer {
   display: flex;
   flex-direction: column;
+  flex-grow: 1;
+  margin-right: 10px;
+  overflow: visible;
+  white-space: normal;
+  word-wrap: break-word;
 }
 
-/* 부제목 (두 번째 카테고리) */
 .subTitle {
   font-size: 14px;
   color: #6c757d;
@@ -41,7 +45,21 @@
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
+  min-width: 180px;
+  flex-shrink: 0;
+}
+
+/* 버튼 공통 스타일 */
+.detailButton,
+.editButton,
+.deleteButton {
+  padding: 8px 14px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  min-width: 75px;
+  text-align: center;
 }
 
 /* 상세 보기 버튼 */

--- a/frontend/src/app/styles/admin/modal/contentDetailModal.module.css
+++ b/frontend/src/app/styles/admin/modal/contentDetailModal.module.css
@@ -46,6 +46,7 @@
   display: flex;
   justify-content: flex-end;
   margin-top: 15px;
+  gap: 10px;
 }
 
 .closeButton {
@@ -60,4 +61,52 @@
 
 .closeButton:hover {
   background-color: #d32f2f;
+}
+
+.relatedTitle {
+  font-size: 18px;
+  font-weight: bold;
+  margin-top: 20px;
+  margin-bottom: 10px;
+  color: #333;
+}
+
+.relatedList {
+  list-style-type: none;
+  padding: 0;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.relatedItem {
+  background: #f9f9f9;
+  padding: 10px;
+  border-radius: 5px;
+  margin-bottom: 5px;
+  font-size: 15px;
+  color: #444;
+  transition: background-coler 0.3s;
+}
+
+.relatedItem:hover {
+  background: #e0e0e0;
+}
+
+.backButton {
+  background-color: #28a745;
+  color: white;
+  border: none;
+  padding: 10px 15px;
+  font-size: 16px;
+  cursor: pointer;
+  border-radius: 5px;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.backButton:hover {
+  background-color: #218838;
+}
+
+.backButton:disabled {
+  display: none;
 }


### PR DESCRIPTION
## 연관된 이슈

> ex) #95

## 작업 내용

- 면접 질문 상세 조회 시 해당 면접 질문의 꼬리 질문 확인 가능
- 면접 질문 수정에서 카테고리 값은 존재하는 카테고리 내에서 변경 가능
- 면접 질문 삭제 시 해당 면접 질문을 기준으로 꼬리 질문까지 삭제

아직 등록 기능을 만들지 않아 이후 추가 예정
카테고리 정렬 기능 추가 예정

## 스크린샷
![image](https://github.com/user-attachments/assets/cb6bf531-53da-479d-a148-b1c068b9779c)
![image](https://github.com/user-attachments/assets/94cd57c3-cbe5-4e25-ab2f-4e90c69f1a99)
![image](https://github.com/user-attachments/assets/2dc7bcf8-8083-45d1-83aa-54087e9d8148)
![image](https://github.com/user-attachments/assets/431097f8-1d39-44f7-acd9-6d9f748ec218)
![image](https://github.com/user-attachments/assets/3040e28a-77e1-4010-811a-05f332fc265c)
![image](https://github.com/user-attachments/assets/b8b8f62a-6ea7-425f-91e1-f94fbc27450a)


## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요

